### PR TITLE
Add servicemonitor ns selector to prom

### DIFF
--- a/prometheus/bases/prometheus/prometheus.yaml
+++ b/prometheus/bases/prometheus/prometheus.yaml
@@ -16,3 +16,6 @@ spec:
   serviceMonitorSelector:
     matchLabels:
       prometheus: dh-prometheus
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      ticket: pnt0817437


### PR DESCRIPTION
> Namespaces to be selected for ServiceMonitor discovery. If nil, only check own namespace.

See API spec [here](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheusspec)

I.e. when adding a new namespace, we need to add a label in this field that the namespace is guaranteed to have. I picked the ticket label since all ns have such a label, we could also ask psi to add labels to the namespace resource and keep it one particular label. 