### PR TITLE
Move all Prometheus Objects to Prometheus Application

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -2,7 +2,7 @@
 
 Kustomize deployment for the Data Hub's internal Prometheus and Grafana instance
 
-### Deploying to Production
+## Deploying to Production
 
 Run the following command from the root of the repository to deploy Prometheus and Alertmanager:
 
@@ -12,38 +12,12 @@ kustomize build prometheus/overlays/prod/ | oc apply -n dh-psi-monitoring -f -
 
 ## Adding New Namespaces for Prometheus to Monitor
 
-**NOTE:** Steps 1 and 2 require cluster admin permissions.
+Give the prometheus service account access to your namespace
 
-1. Make sure that MultiNamespace install is set to true
-
-    ```yaml
-    installModes:
-        - supported: true
-          type: OwnNamespace
-        - supported: true
-          type: SingleNamespace
-        - supported: false
-          type: MultiNamespace
-        - supported: false
-          type: AllNamespaces
-    ```
-
-2. Make sure that `targetNamespaces` in the Prometheus Operator Group has your namespace
-
-    ```yaml
-    spec:
-      targetNamespaces:
-        - dh-psi-monitoring
-        - aicoe-argocd
-        - <new_target_namespace>
-    ```
-
-3. Give the prometheus service account access to your namespace
-
-    ```bash
-    oc project <target_namespace>
-    oc policy add-role-to-user view system:serviceaccount:dh-psi-monitoring:monitoring-sa
-    ```
+```bash
+oc project <target_namespace>
+oc policy add-role-to-user view system:serviceaccount:dh-psi-monitoring:monitoring-sa
+```
 
 ## Alerting
 

--- a/prometheus/overlays/prod/alerting-rules/kustomization.yaml
+++ b/prometheus/overlays/prod/alerting-rules/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ./rsyslog-prometheus-rule.yaml

--- a/prometheus/overlays/prod/alerting-rules/rsyslog-prometheus-rule.yaml
+++ b/prometheus/overlays/prod/alerting-rules/rsyslog-prometheus-rule.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     prometheus: data-hub
     role: alert-rules
-  namespace: dh-prod-ingest
 spec:
   groups:
     - name: ./rsyslog.rules

--- a/prometheus/overlays/prod/kustomization.yaml
+++ b/prometheus/overlays/prod/kustomization.yaml
@@ -3,6 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: dh-psi-monitoring
 resources:
+  - alerting-rules
+  - service-monitors
   - ../../bases/alertmanager
   - ../../bases/blackbox
   - ../../bases/prometheus

--- a/prometheus/overlays/prod/service-monitors/argocd-service-monitor.yaml
+++ b/prometheus/overlays/prod/service-monitors/argocd-service-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    prometheus: dh-prometheus
+  name: argocd-service-monitor
+spec:
+  endpoints:
+    - interval: 30s
+      path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/purpose: argocd-metrics

--- a/prometheus/overlays/prod/service-monitors/kustomization.yaml
+++ b/prometheus/overlays/prod/service-monitors/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- argocd-service-monitor.yaml

--- a/rsyslog/overlays/prod/kustomization.yaml
+++ b/rsyslog/overlays/prod/kustomization.yaml
@@ -1,7 +1,6 @@
 namespace: dh-prod-ingest
 resources:
   - ../../bases/rsyslog
-  - ./rsyslog-prometheus-rule.yaml
 patchesStrategicMerge:
   - rsyslog.yaml
 generators:


### PR DESCRIPTION
Due to multi-namespace installs for operators going away in the near future we will need to use either cluster-wide
or single-namespace installs for operators. Since cluster-wide isn't viable, we will need to have all Prometheus objects (monitors, alerting rules, etc.) in the main prometheus namespace.

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>