### PR TITLE
Add Kafka keystores for Logstash

### DIFF
--- a/logstash/overlays/prod/kustomization.yaml
+++ b/logstash/overlays/prod/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - ../../bases/admin_rolebindings
 patchesStrategicMerge:
   - logstash.yaml
+generators:
+  - ./secrets/secret-generator.yaml

--- a/logstash/overlays/prod/logstash.yaml
+++ b/logstash/overlays/prod/logstash.yaml
@@ -61,6 +61,8 @@ spec:
               mountPath: /etc/pki/tls/certs/
             - name: logstash-certs-keys
               mountPath: /etc/pki/tls/private/
+            - name: kafka-truststore
+              mountPath: /etc/logstash/
         - name: logstash-monitor
           imagePullPolicy: Always
           resources: {}
@@ -72,3 +74,10 @@ spec:
           env:
             - name: LOGSTASH_ENDPOINT
               value: http://localhost:9600
+    volumes:
+      - name: kafka-truststore
+        secret:
+          secretName: kafka-truststore
+          items:
+            - key: keystore.jks
+              path: keystore.jks

--- a/logstash/overlays/prod/secrets/kafka-truststore-secret.enc.yaml
+++ b/logstash/overlays/prod/secrets/kafka-truststore-secret.enc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: kafka-truststore
+data:
+    keystore.jks: ENC[AES256_GCM,data:JzsFYHLvcGuiJvENhDCzSFw5H8hPgpIdHx1/7nLHxkQFq80AuSasEHt7lUwM3O8X5zlR9HGgdIJTgTZsmOh6BYRGlICwCaltFU6L8uO8cFsE+dprKEX8mBDFwWrPEnxsZDaRh5DB84gB3COThuOeWuS0Kw2qTfIu+1FPElBZpO0DdBU9D/GbI0uihK8xfSp4WHdskyU07u5zCPvhE8V0It6R2zaRbC16HNXgFhddVA51mS/BhXiVu3x8d/FHuX0yIcaMHwHeWhpstzW66qxAX9LRbxaDa+Lei4jX83/oaJr7Ytoks+rIQMrZZuxeplYs/+bA4IcvEP5Mf5g28ZptucW4oQqN1ka95lC5V+2TTBao53+EXvD82b3K6E5/oi6k/ChLpvzLKfp7Rs2pNaNCrs0tJCjU5REDD4USVf2CC2r00224n9NirPVhVCc/OL+Q3MYs/Gf6YxqB299INMIBYsJT5gGlauy1C4inqLOPt0T372KOq4ODxdvOiMQsCvHB1QTYLXqbKwIkgwhurCEiVxXPkHw/WJ9pUyBmMQZe0U9WBFhntkPCBxn+6J744+Crg42jVRbCxnJCFdQcKqh6KMudxw9vQxBrfJ7VUkIdtXxQukq9y/Ql7yigQuha9WVk6TONWXVBbExCxt9qFZFjbE8PfhvKdD0Daf9cN0cb6kY/sgNFNuWRxz94Cnay+0knAkeUlikW0fdN9tJhE0g4fcxUFToV9AzqycAUGxQgSyfYr4X750koQzJJpatfzHB+CF16lA+/FrQAuSbbz8qdXqejM/SkhRzc/ljAuR4tr/ctrF51K4SXWbLCIikyvQT1KLFXCRODX7RrWG0a0oRLjYXow3dtNA6GHO7rdXUxPxhJsgqSZXM7EjiPR0ABX/XHwjbCYubBQQAzoEfTqlqkBvgzUmKM+h/9gLIRp2oKZQ58+5aIETHFntZbmojlEr6eKCFMCNwZp2JAmlgspKWgFlfycq8O5pFUm11chV2N3ns2ekv4J7AWamq4mLMXSsZPPG955Bv81wvXwFeTz3LneeTgii1eaPoEQZWFRZng+dBhzVv1vorf7fJVOJlURr8zP4UxTjibwDR43SxiN/+NS7uPxhQV19BWw3SKqPUXqGfz7k7rbPYj1Duqr5u/VmhBBWpF+xN5ZofwbNFcHD6avQnoI1IFiw8Wbaflo0MW2DICXt0rAd/h9vT08/5mkQ8ST/e2KQRUhjF3pxwgWRRlBg7ZNjNOWh3kcZrrAxc/T2x9S0BLYLpLabcE8fMa9MQk5BNm7g3QaO2vNlJpPZCowVBdDNOWRM48ppIriqWBdHM8fkpDI7tMYvWZTW51LnapcgVNbWpb8DPQzlQUe20Q5eTNP2lEabqlvKjeCygJhT/ETKJpYaXGS1kvgR1RJHVs1CM0qbrseOiVT0ZVJLPt9avYeI4RdB0pYl89zbHo53ZLo5oXVCRfK3tgWb0s5CBNyjohHB6Espj5qUpZeHwNRh4aiZXWIJoJB9/bFUqRMyK1iH/GVtHKT34TxZXEJDfriTMD3jfvn49LaBUg02YuI66BS+sH5n5Ngf4CC4DX3NZkVjaufpztqZyEDf8wtjecnWytmYQrETN2Inrx9vPoLvIvDVDXZ3X4UI+Lojc+BOLqRme9oowpNmQRfN4kUqHLMI0H373l405htt6G0nvNJ6RjVAHNSBZcPr1TFkMiuIUbhRd/eqK3glQtiyDnIc7rMrWDnFvECWAM2VD7djZnFcu/Oxh+6JmWZKgeLWWs7VHRBNnrTmXP6DXGXH9BB981a5deY5/yivvY4aUEuvmUv0hG//4meyIs6BWHhFHjrxMPyF9wvE8jlD+hnCncc0ahrC7uUjwn4y+jQZHSbP4ziSErzeSdlOqvw+s2Yv1T3uR5ss3b5UFTTONzhr4kZmiGpT/pEQSwEEQUAP9xxPVN8SrQgL6G48vma4dP2PUbIoxjY4Ju,iv:tZrmwDPgiIkynPPYnT8iQFssfBnie884f6FN1BCZOME=,tag:67y/TvpyIw8fEu+FJz10cg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2021-03-18T15:29:01Z'
+    mac: ENC[AES256_GCM,data:I+VUzIJDTorknpDP/SOF5FAz+TlqHxxxzKP6HLWIahYZRr6KIpgtje7Njn2J5FmrDfgzwUjnfc9oZMYDFJtCqGPmFI6sAWhWCML46GQcV+yZt3hyW6oqdgYBaQyXxPABsGJPfwJ7S0c4Qvj5o12/uVr+BbruUBwMX6hVuw6q0UQ=,iv:+7WnWuLiMTRxqvpNmEL3Ae4WKPsoC54v0zC9G1XD3mI=,tag:wwiAqw1Gg7nazAdWNlBWVg==,type:str]
+    pgp:
+    -   created_at: '2021-03-18T15:28:50Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQf/XVItzAfaoRpBZI4rtWcrT5EoPu2ebihsVlSAS+mFm1Al
+            9gpxL8Pci5MVYk8sWB+IwhP8GiBCkvSIxrRUjNE4qowiZiulFgRFXrg4CjtQ8puW
+            CnFfYkcsIZn08mD1htx7tSTeHJU7XxQxAaByiJBjp/1T085MrabaJWg65OFrJ7Ky
+            4BIAUw5D8Cdgmy2qJ44pojS6Fr66vZvEqQ/OnrTylbnR5f4ZEdQ0jyTiiRZ60Z29
+            EdhE+3xZ2GBzT76TRbWC/kBT2YW+VtRdbT8E8CZIP+pZ2jel576UICQCM6V/2/NK
+            yTR92oIQKNQVKYhp1urEUhF1TvCTG8M+7H85rbFTa9JeATCJyfwoX5jNUq8oSK15
+            /UZo1fihd0Mmjc8ZOL9s9qG0VujYr4c/kEdz46WrGfoXDjHkifMw0iNePIfAJwFb
+            MVPjAFxdyHQwZfikk11F+NDMzUcCffayET+mfR/Ujg==
+            =4IIb
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    encrypted_regex: ^(data|stringData)$
+    version: 3.5.0

--- a/logstash/overlays/prod/secrets/secret-generator.yaml
+++ b/logstash/overlays/prod/secrets/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: kafka-truststore-generator
+files:
+  - ./secrets/kafka-truststore-secret.enc.yaml

--- a/logstash/overlays/stage/kustomization.yaml
+++ b/logstash/overlays/stage/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../bases/admin_rolebindings
 patchesStrategicMerge:
   - logstash.yaml
+generators:
+  - ./secrets/secret-generator.yaml

--- a/logstash/overlays/stage/logstash.yaml
+++ b/logstash/overlays/stage/logstash.yaml
@@ -62,6 +62,8 @@ spec:
               mountPath: /etc/pki/tls/certs/
             - name: logstash-certs-keys
               mountPath: /etc/pki/tls/private/
+            - name: kafka-truststore
+              mountPath: /etc/logstash/
         - name: logstash-monitor
           imagePullPolicy: Always
           resources: {}
@@ -73,3 +75,10 @@ spec:
           env:
             - name: LOGSTASH_ENDPOINT
               value: http://localhost:9600
+    volumes:
+      - name: kafka-truststore
+        secret:
+          secretName: kafka-truststore
+          items:
+            - key: keystore.jks
+              path: keystore.jks

--- a/logstash/overlays/stage/secrets/kafka-truststore-secret.enc.yaml
+++ b/logstash/overlays/stage/secrets/kafka-truststore-secret.enc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: kafka-truststore
+data:
+    keystore.jks: ENC[AES256_GCM,data:o7iQ4GzSr24zlGhFnZEm2dvF5OOmWCTcbJmHW+LvmFLLXmtrmarQROXL9qcSSaKf8whVPhVHizFZ8OifCSbYnDOwYCB0hhwzOMTNrloNM9+V/7R71ldUD/oz9zn3PtJ7YUAhaXSh4lvggngeLjo2GgY5GTMWbeV2KkqNzQx0K8HJbcAey+O5tPXeH/xPXLp6BAqs9+R4NLZMw2h+Zny2aoTQ8auHYA5YB/NKgBkD1zBpNCAplyyhOZjmJoKIX/SlbQEkWiUh0jKkZ3RZVNoCnCRLY51NBbKOadDCxUud05xZ09Evekdr/jVfOr7qAKBIlZIAh6pvgru4zHEk9lfz1Jw8s/0IT/e0HNyK22J2NhJ1SlXC44hIviSHRAkKV2EyRvDDXtQS2DXsY8O4mhB/lCT0fTV0sLzxsfJzllmcRqoSwx17BOX+ZqILh6o3/h8PaFFpWzuvlawtxcLyd0qSfn/oX0K0ihfLKVBscmNUQx/Dixa48ei1HHbyUFCPOgj4oEPWhu+mp6YRqSivWgvF9YeweKmIhhqxlZ1tSaYA9aK/lTxqBSxYXI+xguRnff6idYqhMggf29IK141mze7+ksBs2jO/DbOpsuSyz6f6t9wNJTMfvYFfDvFDsDnupUxM1yPjCPVh3AOoPK0pN9l8trooJWldMZYvh6VWtyV518WCSxqadpZQYQClw4PT2V3BolbCNQHMJPMxIz/yfCaSJQqZ7JfW/jboA9UTwMcQkwKjxlf8B6GgOKhPqkLE3Rf2nldM1jFn+P83R/W9E73YnEpmLzjgz2Xi10/PchKjuI9JLJksK675xonlHRKF4z7ddWgerLxY7SMUkFJqofjmzGV6OUhzGT0GcOZUNiBqYPm7he1IOJ+pNTw5hYptLysj375S5fSwCmKflD1xiyzT1aHIEfo1ItVI7mWL9vPnL0vH8reBnnJI1KiU0zoT43WX4e5hrLd3a6EcgTbdJeaTvJ+vFNRaHBPtKqBHO+R33E87ha+UhcMNxWvMFzbxFKz0bwqQ7FEOO4rE1OkUMXvG6Y7g9SxzdywoKiBpKbmYDB4aZbQQz2zCApgwyhdMHBJP0mUSjZho+hCVEsRXJJGnht5WGG0Ku2SgPdLcyg5fQnHZNWV9AFNgUHK/iC2hmlPoA2n6vRrswMC9clGenZn8AX9tivFB8jVW80vqWMEatPj2YilEiiYDzCLPSEj2CKn/sEaJlOrRjtFbf4XbTPMdpDy43fIt5LnTmEmBcbyq7pCwPUC8na0VF9IJPScY41U6LCTJ3f7hXOUg4zBzfsRVEftXlqsge+m+lC5lcwBakOrcqCrB26EX++iYiYURiHUZDIf5h1TB6M4EBKxBlg6I3MIiHbW0QLwMmO4aRuQOhF/x3sLv/w+fd1EZ+9Xu+GODc4AXb7ilT3UJbIbbfPVhHfwZgvNNSQlAck0u5hEpQWLjk5JKDl66SNanuS3qziQcdaW5b90Ey3GgMUcbELg7/H1p+L675cVONNAgQ5Gn16euoxbAwFxia/palcZKeAoZy6m1X9WVZO74Akg0aO2+fJNcXL5MVLX01lb6P8e+3s1j7AL3oAOM17td1XvDfFG4es0pMMM6Y++kVz4PcYYMYnSHBBPDxXyYVeEGpezDjDqX0IXDGUIrCqSKQoB1m/YlSKvG2pLgi63g4ahFmCFUSX3rbjiGVdHiiP7vhftlqQ40+dW3zDF7HCNB6BuHdiMJYNKi/2m1g8AK9i5SCG6SNj9L7SvIGY/EA9rfd//RhIPvWPBoDL89elW+sL0klrxmlvd3pyh5A7o79+p2eXrGkbYvfbyCng5O+Qp9mt/pZbaxWrT/G6fGPDyCChdIFJmPlRYJBOhoYuNagjDQ2WqqPMIukoHNusjH52F523lfV7r8r5Zmls/DyfQfiiQM0gsyK30l6fsdOP6a+uaRRRsggeZm4OdP2MK5Hat8BVAQIWkcXw9B,iv:eRq9VZ88qlWpXHps+I0aixSqDYD2y43a/wgh0iHMlNU=,tag:hr2Bb6S42vaxfTQKtrleRw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2021-03-18T15:30:00Z'
+    mac: ENC[AES256_GCM,data:U+jkOIhnJWV/ZgWtqjYVqyo4XX9E1TDLjKYrEJkByPi1VO5AiTK5LqrzFTOTMeQhFh0X7UF56IfQJuc0z71T+16Cbo77U11y6Mj1JGX23FZoZNOhiNZCGEIUpTi5vdAqsdYjCcixDu29CvYb8U8NLR76hSwGRTZEJTJxvcL59zk=,iv:XFCtWm1nU0csE9Z72GSZFkfgoGiH4GdKGJ6Mbck5/Y0=,tag:kRPkW6IzK6kNVOBZEj5VVg==,type:str]
+    pgp:
+    -   created_at: '2021-03-18T15:30:00Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQf/fnUovBYpDL0T7D9iq1djPgGUt0dfVKZQYFCyXb6K96xr
+            3mVtfGtKQ54TYDez/jnPA4YD/p95HxCOziBx4u0yey2ZDOrQSHLTmcep6BiiRO5O
+            Hg5w6BUNz2ZKYkguLwVEohXUguDiMgbGi7VroTTakpsECpJeRDk9qjiJGX1mn0lE
+            JHJUXPFFu9mI3VUoTeFSfeDnNlsR5hPRPWFnFw9ptAhnMF6ljcYHl3+yTB0fKCFq
+            9pFukXUcAUSJzZSG4JZ2vZ2FRe/jQ+MS749k6zzOeHNSdQu+ty+R30CctJjiZMXt
+            eu4SfHYO/1fgTqSqfXR71SgY6Qu27OdX0GpNyIaYk9JeAW8qC/nQv8Wp9yyV3VLq
+            hNzsZCJUQrGJWVMyR4AFkkagZyQG3sDTq4SrZ17MoYIpX6ErfAcmIFr+qMKUq/VZ
+            SBE+WvjMkW8iMPqdFG6buwtddWyRrQ5hYkqhihM/Ug==
+            =JoD1
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    encrypted_regex: ^(data|stringData)$
+    version: 3.5.0

--- a/logstash/overlays/stage/secrets/secret-generator.yaml
+++ b/logstash/overlays/stage/secrets/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: kafka-truststore-generator
+files:
+  - ./secrets/kafka-truststore-secret.enc.yaml


### PR DESCRIPTION
The secrets were generated by running `cat truststore-<env>.jks | base64 | pbcopy` before being encrypted by sops.

This PR will mount the keystores at `/etc/logstash/`

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>