### PR TITLE
Remove Obslytics Dataviz DC Image Spec, Add csv_succeeded metric

### DIFF
--- a/obslytics/bases/dataviz.yaml
+++ b/obslytics/bases/dataviz.yaml
@@ -18,7 +18,6 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: obslytics-data-exporter
-          image: docker-registry.default.svc:5000/dh-prod-thanos-extractor/obslytics-pyscripts:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/obslytics/overlays/dev/dataviz.yaml
+++ b/obslytics/overlays/dev/dataviz.yaml
@@ -1,8 +1,4 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/0/image
-  value: quay.io/gmfrasca/obslytics-pyscripts:latest
-
-- op: replace
   path: /spec/template/spec/containers/0/env/2/value
   value: devdemo/

--- a/obslytics/overlays/prod/dataviz.yaml
+++ b/obslytics/overlays/prod/dataviz.yaml
@@ -1,8 +1,4 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/0/image
-  value: docker-registry.default.svc:5000/dh-prod-thanos-extractor/obslytics-pyscripts:latest
-
-- op: replace
   path: /spec/template/spec/containers/0/env/2/value
   value: data/

--- a/obslytics/overlays/prod/triggers.yaml
+++ b/obslytics/overlays/prod/triggers.yaml
@@ -21,6 +21,7 @@
     - visual_web_terminal_sessions_total
     - acm_managed_cluster_info
     - cluster:usage:consumption:rhods:cpu:seconds:rate5m
+    - csv_succeeded
 - op: replace
   path: /spec/templates/1/steps/1/0/withParam
   value:
@@ -43,6 +44,7 @@
     - visual_web_terminal_sessions_total
     - acm_managed_cluster_info
     - cluster:usage:consumption:rhods:cpu:seconds:rate5m
+    - csv_succeeded
 - op: replace
   path: /spec/templates/2/steps/0/0/withParam
   value:
@@ -65,3 +67,4 @@
     - visual_web_terminal_sessions_total
     - acm_managed_cluster_info
     - cluster:usage:consumption:rhods:cpu:seconds:rate5m
+    - csv_succeeded

--- a/obslytics/overlays/stage/dataviz.yaml
+++ b/obslytics/overlays/stage/dataviz.yaml
@@ -1,8 +1,4 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/0/image
-  value: docker-registry.default.svc:5000/dh-prod-thanos-extractor/obslytics-pyscripts:latest
-
-- op: replace
   path: /spec/template/spec/containers/0/env/2/value
   value: data/


### PR DESCRIPTION
- Remove DC image spec as it is automatically updated by ImageChange trigger
- Add csv_succeeded to Obslytics metric list
- DATAHUB-18