### PR TITLE
Reduce retryStrategy amount for cron workflow

### DIFF
--- a/obslytics/overlays/prod/workflow-templates.yaml
+++ b/obslytics/overlays/prod/workflow-templates.yaml
@@ -58,7 +58,7 @@
 
 - op: replace
   path: /spec/templates/5/retryStrategy/limit
-  value: 5
+  value: 1
 
 - op: replace
   path: /spec/templates/5/script/image


### PR DESCRIPTION
With Gap Detection in place, this can be a huge misues of time resource,
(6 consecutive fails x 10m timeouts = 1 hr runtime).  Therefore, reduce retries to 1 (for 2 tries total before aborting)