### PR TITLE
Add clusterrolebindings for telemetry grafana SAs

### DIFF
--- a/telemetry-grafana/overlays/prod/privileged/grafana-cluster-role-binding.yaml
+++ b/telemetry-grafana/overlays/prod/privileged/grafana-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-auth-delegator
+roleRef:
+  kind: ClusterRole
+  name: system:auth-delegator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: grafana
+    namespace: dh-prod-telemetry-grafana

--- a/telemetry-grafana/overlays/sandbox/privileged/grafana-cluster-role-binding.yaml
+++ b/telemetry-grafana/overlays/sandbox/privileged/grafana-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-auth-delegator
+roleRef:
+  kind: ClusterRole
+  name: system:auth-delegator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: grafana
+    namespace: dh-sandbox-telemetry-grafana


### PR DESCRIPTION
These are necessary for the telemetry oauth proxies to work. These will
need to be applied by someone with cluster admin (PSI). As such, they
are in the `privileged` subdirectories of the prod and sandbox overlay
directories.