### PR TITLE
Change the oauth proxy image and point to a specific version

### DIFF
--- a/telemetry-grafana/base/grafana-deploymentconfig.yaml
+++ b/telemetry-grafana/base/grafana-deploymentconfig.yaml
@@ -90,7 +90,7 @@ spec:
             - mountPath: /grafana-dashboard-definitions
               name: grafana-dashboard-definitions
         - name: auth-proxy
-          image: registry.redhat.io/openshift4/ose-oauth-proxy
+          image: quay.io/openshift/origin-oauth-proxy:4.8.0
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
We previosly did not pin to a specific version of the oauth proxy image.
This resulted in an outage when the available image changed. This change
pins to a known working image.