### PR TITLE
Bump Paralellism on OCP4 Obslytics ETL Pipelines

### DIFF
--- a/obslytics/overlays/ocp4-migration/triggers.yaml
+++ b/obslytics/overlays/ocp4-migration/triggers.yaml
@@ -81,3 +81,7 @@
     - rhods_aggregate_availability
     # TODO: add the following metrics to this list
     # - cluster_operator_conditions  # TODO: times out
+
+- op: replace
+  path: /spec/templates/1/parallelism
+  value: 10

--- a/obslytics/overlays/ocp4-migration/workflow-templates.yaml
+++ b/obslytics/overlays/ocp4-migration/workflow-templates.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/templates/0/parallelism
-  value: 2
+  value: 10
 
 - op: replace
   path: /spec/templates/1/dag/tasks/0/arguments/parameters/5/value


### PR DESCRIPTION
- Increase Parallel worker pods from 2/3 to 10 for Obslytics pipelines
  to more fully utilize available resources