### PR TITLE
Adjust Backfill Minimum Timestamp

### DIFF
--- a/obslytics/bases/triggers.yaml
+++ b/obslytics/bases/triggers.yaml
@@ -52,7 +52,7 @@ spec:
                 - name: backfill_from_timestamp
                   value: "{{workflow.parameters.start_timestamp}}"
                 - name: backfill_min_ts
-                  value: 2019-05-30T00:00:00Z
+                  value: 2019-05-30T23:59:59Z  # TODO: figure out a way to determine this dynamically
             templateRef:
               name: obslytics-data-exporter-workflow-template
               template: normalize-timestamps


### PR DESCRIPTION
Turns out that it is off by ~3 hours.  This should make the minimum timestamp cutoff June 1, 2019 at midnight GMT.