### PR TITLE
Add a service account for sandbox telemetry grafana

### DIFF
--- a/telemetry-grafana/overlays/sandbox/data-foundation-pms-serviceaccount.yaml
+++ b/telemetry-grafana/overlays/sandbox/data-foundation-pms-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: data-foundation-pms

--- a/telemetry-grafana/overlays/sandbox/kustomization.yaml
+++ b/telemetry-grafana/overlays/sandbox/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   - ../../base
+  - data-foundation-pms-serviceaccount.yaml
 
 generators:
   - ./secret-generator.yaml


### PR DESCRIPTION
The data foundations PMs team has requested a service account to access
telemetry grafana. This creates it.