### PR TITLE
Add blackbox exporter

### DIFF
--- a/kfdefs/base/trino/kustomization.yaml
+++ b/kfdefs/base/trino/kustomization.yaml
@@ -14,6 +14,7 @@ patchesStrategicMerge:
 
 resources:
   - trino-service-monitor.yaml
+  - trino-blackbox-service-monitor.yaml
 
 generators:
 - ./secret-generator.yaml

--- a/kfdefs/base/trino/trino-blackbox-service-monitor.yaml
+++ b/kfdefs/base/trino/trino-blackbox-service-monitor.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trino-blackbox-service-monitor
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - sourceLabels:
+            - __address__
+          targetLabel: __param_target
+        - sourceLabels:
+            - __param_target
+          targetLabel: instance
+        - replacement: 'https://trino.datahub.redhat.com/'
+          targetLabel: target
+      params:
+        module:
+          - http_2xx
+        target:
+          - 'https://trino.datahub.redhat.com/'
+      path: /probe
+      targetPort: 9115
+  jobLabel: prometheus.io/joblabel
+  namespaceSelector:
+    matchNames:
+      - dh-prod-monitoring
+  selector:
+    matchLabels:
+      prometheus.io/scrape: 'true'

--- a/monitoring/.sops.yaml
+++ b/monitoring/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: "^(data|stringData|tls)$"
+    pgp: "EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E"

--- a/monitoring/base/blackbox-exporter.yaml
+++ b/monitoring/base/blackbox-exporter.yaml
@@ -31,6 +31,8 @@ data:
           method: GET
           valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
           preferred_ip_protocol: "ip4"
+          tls_config:
+            ca_file: /etc/certs/caCertificate
 
 ---
 apiVersion: apps/v1
@@ -53,6 +55,9 @@ spec:
       - name: config-volume
         configMap:
           name: blackbox
+      - name: rh-it-ca-certificate-secret
+        secret:
+          secretName: rh-it-ca-certificate-secret
       containers:
       - image: quay.io/integreatly/prometheus-blackbox-exporter:v0.19.0
         name: blackbox-exporter
@@ -62,6 +67,9 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /tmp
+        - mountPath: "/etc/certs"
+          name: rh-it-ca-certificate-secret
+          readOnly: true
         ports:
         - containerPort: 9115
           protocol: TCP

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -2,5 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+generators:
+  - secret-generator.yaml
+
 resources:
   - blackbox-exporter.yaml

--- a/monitoring/base/rh-it-ca-certificate-secret.enc.yaml
+++ b/monitoring/base/rh-it-ca-certificate-secret.enc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: rh-it-ca-certificate-secret
+    labels:
+        app: blackbox-exporter
+stringData:
+    caCertificate: ENC[AES256_GCM,data:4cP4x+d6iGuSmgShHU05rgaQ7QtPpuIjdeRWqoTrnXUnhMvokunUcHzXw/IwEwTBlaoLBV9gXNQhcarJqUUFR4QU2W2hoxtTU+OeZLgQ27Nxan5PcFSaHQXxhb8ucbPUghR0I4meo3MdcedbqnrdhI3zpCuGrVWr5dhEAmNE6lUZxSbGRL/fHDMkZXWrWL1r5jNpY3rUiscwVpLT+YHGrOEA5tKxEovD2FsPjBfMOmFlL13edQShcXCJ5KDIqjtKsBbIOmJiN902EePFa0C2aR0RzNjX6YpZBU+IuyLj21lmfzkv4g8TXjp3bYlREoiHfAIDrkpcEGJkcP3ET3YrtwaoWELvn57pW4aHzifr/yb/jPhEB961/jVW7OoRD/lyX5V/1aa06u/C+fqoYS5Du+hFKR7wrObK1Vojwx23SbSukDydomSz5O7JhXbN42SacgThQ3TSlIk98z/JUejOhiZrWTF2WseGrBQEnXRXLbgEmAwi/SFsIboQcqBFOEZkgHfENYUnOMEuVVn1R7EjPOOrAthrpyeYh7Tlpn6/DlwDmb7SvnlhzZQ2IgRQNemUUPL/OgEkYGSIrybM61FguR2dx0pFq23ip6WS3Eon9JDgZbi8ujLiKB3KZSshraaQlYVEbJ91ZrKZanWnwnV0fgo27IBhBDedMUDVjIXapUXc2e9DK2jfDwUDn++P4+cYzk4JfBSIhZ9Z9YJDkMtqQRstca77LdlO52H3Gin2Ro7hhbCFkhlNUH03uDHhO/VB7n9q5a2tFrxuML/Xr8xv3sQsbsi5Ot2IT49uZNCpjvR0WkDh96AWAQqrLLuowbk2D3SDPSUAs/dhyouf9i26cK0NW4Y370XABeYYyWolPA3m/ThDRhB/IJxvRP9A7fMrXNHlKZSvy68sSU5270z4yVAdrvKs5nLqDjTv1bW0Mwt6Q/8kjuRZwvK63JmveCY2QmzhJYKakWUQdaFYrq5q6LcYfaIZVL7PPjXtsu+2ALTovSf14CpiNaSOlAw851Ga3CCpfKqbHuMzmT6FO+ujncKxmE1iZSn2DXe/tu+T1G1dsmQ6Q5nGr6V3OpSa005beul4oq9Cp/l0tJrUxDHO2EWnVaDF52IWUT3aYAzXO4r1NU2ck49ZW44eDFjcGnZmvkS8jkSE6pIHBf6FxWSdwqxGcHLylU6TOZvvjuiB+0JeS6mJniAoPL8trHeBiyeuMyMbzyXhSc1MBCepOZU4NryBvlEoPHcnKiIqq8fOvaVFT99Ss+ps7o9yoM8seqRivHgRW0V7Qpph4Qzf0yQzv2kBulCMhKwrkKOGrk7q/p01GaxtNdRVhrjiUAqWAQeO0mh4s2kPwag2Pqq9gMCWi4sSI4T5QeeSouQM3meDGMrS1TyCmUdW3X28FaWPZ8oWKFUNMD1fdgxQDhivp6QtDgq+eE8ZnWXnUzNB/yBeoxlamoX+IgiMjwLgqiYtzCGSIMHEfCtCfrd58+H6KydoiUTv2Excoaeh7bMO048ApjfXYNAyKXa9rQDSiBMCCadefsbgwQOF3OnBZls9LvPdmB5rqrnDtZkCKlwYW+K8u3UX/0xLGtnTrsRNzMN/rsVxEhEaYcXaEwxPtuBQzAFrw3jxIWWWikXZQtrhRacgm5P6Xfx4gtBkFBeh7HK1jKNkgps2lc4j+LkHi9wObyTo9ulosOwTEtgnL9VZn0i38eJfBIWUi1clTbUGGNTCq36BTgu+3l7Mx6atZmYNOpiX1BKfqpAe/XHE1CPVaEGFlhyn74X9dlXxWirzlJIG/gCCGo9kUN0i8nK3LPsqJ9U4BqIHUTSWqEYbL0S6sLG6WYzGwBkHy6ydsPX8DNFF7MBCQEEeXEbhW3ry/b/C4L18UASS0HA2x7rraZYDc0uO1SilZOrbPLQ1ja1yK/5xaqE0dEIoUOyUpbX8Nj0htskIDcb1oreMc5Bwdqn2aQipQ+667JB/07MBiwWqY/0b+SXY9O5D4yBtQENw4yXoPDv5vjN4Hv5lQ3lz4I7qow==,iv:jH+ShgGP4jl/WdstpZv+pf2giWBEhYuNgGq4CpE1eXU=,tag:3jS9hMuIpWpvTYec/FM1xw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2021-11-11T21:18:38Z'
+    mac: ENC[AES256_GCM,data:E1MPLFnLe0y7mK11u0+JtWbV9V5xHT3Phfn6YujVAhG7cwHYv062+SDdDBmMJujBkMNj+TjB0m2H1/XnI9wwpWjVyuRDlccbR999Mh+iv0TPkPvlWlJtwVMH4v0ea67E2MST+TqI8c9LSNLXNAYV+7G6TH2D6Wrle3p4/XMw9GU=,iv:sxyUiLLkXJJRRe5mwc7fY/8cSoDiME5Nhbf1wjMrucI=,tag:omSgqRXLaDcnpcIprhDVnw==,type:str]
+    pgp:
+    -   created_at: '2021-11-11T21:18:38Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQf/SVUx7JAZhtdpHqdtM+GtxWqFsdGOshGO0Ry3NAAWSLK7
+            pHE1FEz/8IdMnEiuNUUhRUrWoeCJH5g/nn9SjU2Nbpdj6itlzkQWyw3p7kL9J804
+            axHqGyA/CRtXaQ84e4fgvqtsCn+b5kgkcrVzeQwdwtoVFvjJsMqBlrxioUOxYYBO
+            QrUCCycuV/+ZxnTG4SowN+m5dm+FOSrQBdT2evmU33+iEpzvp3UWRdMtoDH+fOsn
+            fUKWRVame7HZnM9BJ5wtHzDkdCBFFQmz5Mq6m62OH2dMKEqb5wOWCz1FA0nAtmaq
+            HZK8jcoOfUW5rjle6TegixTmn0GYCqJG0EJxQDYkh9JeAf8j5ga2UxLYx9olt2cW
+            WY/xWwHo0G/SbKtaGwY8G1m20pDvGygA4Y+/j7jpU070R3Jjv6IcrESK2Uk0hCdm
+            G1u96LrQyBJ6hBMmB4Cyoh+q38sF6L6i43BPntsEBw==
+            =ntrx
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.5.0

--- a/monitoring/base/secret-generator.yaml
+++ b/monitoring/base/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - rh-it-ca-certificate-secret.enc.yaml


### PR DESCRIPTION
This PR adds a blackbox exporter monitor for Trino as well as mounting the Red Hat IT cert in the blackbox exporter pod