### PR TITLE
Move blackbox probes to monitoring kustomize directory

### DIFF
--- a/datahub-help/base/kustomization.yaml
+++ b/datahub-help/base/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - stasis-reactor-deployment-config.yaml
   - stasis-reactor-service.yaml
   - stasis-reactor-route.yaml
-  - datahub-help-blackbox-service-monitor.yaml
 
 generators:
   - ./secret-generator.yaml

--- a/kfdefs/base/trino/kustomization.yaml
+++ b/kfdefs/base/trino/kustomization.yaml
@@ -14,7 +14,6 @@ patchesStrategicMerge:
 
 resources:
   - trino-service-monitor.yaml
-  - trino-blackbox-service-monitor.yaml
 
 generators:
 - ./secret-generator.yaml

--- a/monitoring/base/datahub-help-blackbox-service-monitor.yaml
+++ b/monitoring/base/datahub-help-blackbox-service-monitor.yaml
@@ -24,6 +24,8 @@ spec:
   jobLabel: prometheus.io/joblabel
   namespaceSelector:
     matchNames:
+      - dh-dev-monitoring
+      - dh-stage-monitoring
       - dh-prod-monitoring
   selector:
     matchLabels:

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -7,3 +7,5 @@ generators:
 
 resources:
   - blackbox-exporter.yaml
+  - datahub-help-blackbox-service-monitor.yaml
+  - trino-blackbox-service-monitor.yaml

--- a/monitoring/base/trino-blackbox-service-monitor.yaml
+++ b/monitoring/base/trino-blackbox-service-monitor.yaml
@@ -24,6 +24,8 @@ spec:
   jobLabel: prometheus.io/joblabel
   namespaceSelector:
     matchNames:
+      - dh-dev-monitoring
+      - dh-stage-monitoring
       - dh-prod-monitoring
   selector:
     matchLabels:


### PR DESCRIPTION
In order for our blackbox endpoint probes to work correctly, their
service monitor objects must be deployed into the same namespace as the
blackbox exporter service. This change moves the service monitor
definitions into the blackbox exporter deployment to achieve that.