### PR TITLE
Fix argocd for stage telemetry grafana

### DIFF
--- a/telemetry-grafana/overlays/stage/grafana-cluster-role-binding.yaml
+++ b/telemetry-grafana/overlays/stage/grafana-cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: grafana-auth-delegator
 roleRef:


### PR DESCRIPTION
ArgoCD didn't like applying a clusterrolebinding for stage telemetry
grafana's auth-delegator role. This change switches the rolebinding to a
namespace-scoped rolebinding grantint the cluster role, which should
work just fine and appease ArgoCD.