### PR TITLE
Rollback Trino memory changes

### DIFF
--- a/kfdefs/overlays/prod/dh-prod-trino/kustomization.yaml
+++ b/kfdefs/overlays/prod/dh-prod-trino/kustomization.yaml
@@ -77,7 +77,7 @@ patchesJson6902:
   - patch: |
       - op: replace
         path: /data/trino_memory_limit
-        value: '64Gi'
+        value: '32Gi'
     target:
       kind: ConfigMap
       name: trino-config

--- a/kfdefs/overlays/prod/dh-prod-trino/trino-config-secret.yaml
+++ b/kfdefs/overlays/prod/dh-prod-trino/trino-config-secret.yaml
@@ -13,13 +13,13 @@ stringData:
     http-server.authentication.type=PASSWORD
     http-server.process-forwarded=true
     password-authenticator.config-files=/etc/trino/ldap-authenticator.properties,/etc/trino/file-authenticator.properties
-    query.max-memory-per-node=12GB
-    query.max-total-memory-per-node=18GB
-    query.max-memory=32GB
+    query.max-memory-per-node=6GB
+    query.max-total-memory-per-node=12GB
+    query.max-memory=24GB
   config-worker.properties: |-
     coordinator=false
     http-server.http.port=8080
     discovery.uri=http://trino-service:8080
-    query.max-memory-per-node=12GB
-    query.max-total-memory-per-node=18GB
-    query.max-memory=32GB
+    query.max-memory-per-node=6GB
+    query.max-total-memory-per-node=12GB
+    query.max-memory=24GB


### PR DESCRIPTION
Trino can't handle the amount of memory with the number of CPUs and current JVM configuration. Rolling back the changes for now until we find the best configuration to handle this.