### PR TITLE
Upgrade superset to 1.3.0

### DIFF
--- a/kfdefs/overlays/prod/dh-prod-superset/kustomization.yaml
+++ b/kfdefs/overlays/prod/dh-prod-superset/kustomization.yaml
@@ -120,8 +120,3 @@ patchesJson6902:
 patchesStrategicMerge:
   - ./supersetdb-deployment-pvc-backup.yaml
   - ./supersetdb-service-nodePort.yaml
-
-images:
-  - name: quay.io/opendatahub/superset:1.3.0
-    newName: quay.io/opendatahub/superset
-    newTag: "1.1.0"


### PR DESCRIPTION
Remove our superset image version pin so we pull from the image that
upstream odh uses, which is 1.3.0 currently.