### PR TITLE
Add prod redirect reference for superset service account

### DIFF
--- a/kfdefs/overlays/prod/dh-prod-superset/kustomization.yaml
+++ b/kfdefs/overlays/prod/dh-prod-superset/kustomization.yaml
@@ -120,3 +120,4 @@ patchesJson6902:
 patchesStrategicMerge:
   - ./supersetdb-deployment-pvc-backup.yaml
   - ./supersetdb-service-nodePort.yaml
+  - ./superset-service-account.yaml

--- a/kfdefs/overlays/prod/dh-prod-superset/superset-service-account.yaml
+++ b/kfdefs/overlays/prod/dh-prod-superset/superset-service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: superset
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirectreference.second: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"superset-datahub"}}'


### PR DESCRIPTION
In order for Superset OAuth to work, the Superset service account needs
to have an annotation referencing any route used to access Superset.
This adds that annotation for the superset.datahub.redhat.com route.