### PR TITLE
Add deployment for superset bareos-fd pod

### DIFF
--- a/kfdefs/overlays/prod/dh-prod-superset/bareos-fd-deploymentconfig.yaml
+++ b/kfdefs/overlays/prod/dh-prod-superset/bareos-fd-deploymentconfig.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: bareos-fd
+  name: bareos-fd
+spec:
+  replicas: 1
+  selector:
+    app: bareos-fd
+    deploymentconfig: bareos-fd
+  strategy:
+    type: Rolling
+  template:
+    metadata:
+      labels:
+        app: bareos-fd
+        deploymentconfig: bareos-fd
+    spec:
+      containers:
+        - env:
+          - name: PGPASSWORD
+            value: backups
+          imagePullPolicy: Always
+          name: bareos-fd
+          volumeMounts:
+            - mountPath: /etc/bareos
+              name: bareos-fd-config
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: bareos-fd-config
+          name: bareos-fd-config
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - bareos-fd
+        from:
+          kind: ImageStreamTag
+          name: bareos-fd:latest

--- a/kfdefs/overlays/prod/dh-prod-superset/bareos-fd-imagestream.yaml
+++ b/kfdefs/overlays/prod/dh-prod-superset/bareos-fd-imagestream.yaml
@@ -1,0 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: bareos-fd
+  name: bareos-fd
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: docker-registry-default.cloud.registry.upshift.redhat.com/bareos/bareos-fd-psql:9.6
+      referencePolicy:
+        type: Source

--- a/kfdefs/overlays/prod/dh-prod-superset/kustomization.yaml
+++ b/kfdefs/overlays/prod/dh-prod-superset/kustomization.yaml
@@ -6,6 +6,8 @@ namespace: dh-prod-superset
 resources:
   - ../../../base/superset
   - supersetdb-route.yaml
+  - bareos-fd-deploymentconfig.yaml
+  - bareos-fd-imagestream.yaml
 
 generators:
   - secret-generator.yaml


### PR DESCRIPTION
This pod and the corresponding image stream are necessary for the
superset backups to complete.