### PR TITLE
Migrate idh-manifests kafka to internal data hub repository

### DIFF
--- a/kfdefs/base/kafka/kafka-cluster.yaml
+++ b/kfdefs/base/kafka/kafka-cluster.yaml
@@ -1,0 +1,244 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kafka-metrics
+  labels:
+    app: strimzi
+data:
+  kafka-metrics-config.yml: |
+    # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
+    lowercaseOutputName: true
+    rules:
+    # Special cases and very specific rules
+    - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+      name: kafka_server_$1_$2
+      type: GAUGE
+      labels:
+       clientId: "$3"
+       topic: "$4"
+       partition: "$5"
+    - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
+      name: kafka_server_$1_$2
+      type: GAUGE
+      labels:
+       clientId: "$3"
+       broker: "$4:$5"
+    - pattern: kafka.server<type=(.+), cipher=(.+), protocol=(.+), listener=(.+), networkProcessor=(.+)><>connections
+      name: kafka_server_$1_connections_tls_info
+      type: GAUGE
+      labels:
+        cipher: "$2"
+        protocol: "$3"
+        listener: "$4"
+        networkProcessor: "$5"
+    - pattern: kafka.server<type=(.+), clientSoftwareName=(.+), clientSoftwareVersion=(.+), listener=(.+), networkProcessor=(.+)><>connections
+      name: kafka_server_$1_connections_software
+      type: GAUGE
+      labels:
+        clientSoftwareName: "$2"
+        clientSoftwareVersion: "$3"
+        listener: "$4"
+        networkProcessor: "$5"
+    - pattern: "kafka.server<type=(.+), listener=(.+), networkProcessor=(.+)><>(.+):"
+      name: kafka_server_$1_$4
+      type: GAUGE
+      labels:
+       listener: "$2"
+       networkProcessor: "$3"
+    - pattern: kafka.server<type=(.+), listener=(.+), networkProcessor=(.+)><>(.+)
+      name: kafka_server_$1_$4
+      type: GAUGE
+      labels:
+       listener: "$2"
+       networkProcessor: "$3"
+    # Some percent metrics use MeanRate attribute
+    # Ex) kafka.server<type=(KafkaRequestHandlerPool), name=(RequestHandlerAvgIdlePercent)><>MeanRate
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
+      name: kafka_$1_$2_$3_percent
+      type: GAUGE
+    # Generic gauges for percents
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>Value
+      name: kafka_$1_$2_$3_percent
+      type: GAUGE
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*, (.+)=(.+)><>Value
+      name: kafka_$1_$2_$3_percent
+      type: GAUGE
+      labels:
+        "$4": "$5"
+    # Generic per-second counters with 0-2 key/value pairs
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+      labels:
+        "$4": "$5"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+    # Generic gauges with 0-2 key/value pairs
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
+      name: kafka_$1_$2_$3
+      type: GAUGE
+    # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
+    # Note that these are missing the '_sum' metric!
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_count
+      type: COUNTER
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+        quantile: "0.$8"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_count
+      type: COUNTER
+      labels:
+        "$4": "$5"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+        quantile: "0.$6"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
+      name: kafka_$1_$2_$3_count
+      type: COUNTER
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        quantile: "0.$4"
+  zookeeper-metrics-config.yml: |
+    # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
+    lowercaseOutputName: true
+    rules:
+    # replicated Zookeeper
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
+      name: "zookeeper_$2"
+      type: GAUGE
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
+      name: "zookeeper_$3"
+      type: GAUGE
+      labels:
+        replicaId: "$2"
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(Packets\\w+)"
+      name: "zookeeper_$4"
+      type: COUNTER
+      labels:
+        replicaId: "$2"
+        memberType: "$3"
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
+      name: "zookeeper_$4"
+      type: GAUGE
+      labels:
+        replicaId: "$2"
+        memberType: "$3"
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
+      name: "zookeeper_$4_$5"
+      type: GAUGE
+      labels:
+        replicaId: "$2"
+        memberType: "$3"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: "three"
+spec:
+  kafkaExporter: {}
+  kafka:
+    version: "3.0.0"
+    readinessProbe:
+      initialDelaySeconds: 15
+    livenessProbe:
+      initialDelaySeconds: 15
+    template:
+      pod:
+        tolerations:
+        - effect: NoSchedule
+          key: provider
+          operator: Equal
+          value: gpu-baremetal
+
+        affinity:
+          # We do not want the Kafka nodes to run on our Baremetal Elasticsearch
+          # nodes. See http://strimzi.io/docs/0.8.1/#assembly-scheduling-deployment-configuration-kafka-connect
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: "node-role.kubernetes.io/worker"
+                    operator: In
+                    values:
+                      - ""
+    replicas: 1
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics
+          key: kafka-metrics-config.yml
+    listeners:
+      - name: plain
+        port: 9092
+        tls: true
+        type: route
+      - name: internal
+        port: 9093
+        tls: false
+        type: internal
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      min.insync.replicas: 1
+      log.retention.hours: 48
+      num.partitions: 2
+      num.recovery.threads.per.data.dir: 1
+      auto.create.topics.enable: false
+      log.message.format.version: "3.0.0"
+      default.replication.factor: 1
+
+
+    storage:
+      type: persistent-claim
+      size: "10Gi"
+      class: "standard"
+      deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: "10Gi"
+      class: "standard"
+      deleteClaim: false
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics
+          key: zookeeper-metrics-config.yml
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/kfdefs/base/kafka/kafka-operator-service.yaml
+++ b/kfdefs/base/kafka/kafka-operator-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scheme: http
+    prometheus.io/scrape: 'true'
+  labels:
+    name: strimzi-cluster-operator
+    strimzi.io/kind: cluster-operator
+  name: strimzi-cluster-operator
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    strimzi.io/kind: cluster-operator
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+  apiVersion: v1

--- a/kfdefs/base/kafka/kustomization.yaml
+++ b/kfdefs/base/kafka/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: idh-message-bus
+
+resources:
+  - kafka-cluster.yaml
+  - kafka-operator-service.yaml

--- a/kfdefs/overlays/dev/dh-dev-message-bus/kafka-topics.yaml
+++ b/kfdefs/overlays/dev/dh-dev-message-bus/kafka-topics.yaml
@@ -1,0 +1,1539 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.pipeline
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ciumb.trans20180907.cvp.pipeline
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ciumb.trans20180907.cvp.stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ciumb.trans20180907.cvp.test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.non-cvp
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ciumb.trans20180907.non-cvp
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dh-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dh-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: fedmsg.production
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: fedmsg.production
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.fluentd
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ingest.fluentd
+  config:
+    retention.ms: 86400000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.logstash
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ingest.logstash
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.rsyslog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 10
+  replicas: 1
+  topicName: ingest.rsyslog
+  config:
+    retention.ms: 86400000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: quayingest.prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: quayingest.prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-shipshift-prod-logs-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 14
+  replicas: 1
+  topicName: dynamic-shipshift-prod-logs-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: umbingest.prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: umbingest.prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-radas
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-radas
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-3sn-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-3sn-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-3sn-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-3sn-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccit-lfa-alpha
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-ccit-lfa-alpha
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: dynamic-pnc-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-stage-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: dynamic-pnc-stage-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-dev-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: dynamic-pnc-dev-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-indy-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 20
+  replicas: 1
+  topicName: dynamic-indy-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-metaxor-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-metaxor-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-metaxor-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-metaxor-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 14
+  replicas: 1
+  topicName: dynamic-quay-io-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-staging
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 6
+  replicas: 1
+  topicName: dynamic-quay-io-staging
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-testing
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-quay-io-testing
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-container-repo-auto-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-container-repo-auto-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-container-repo-auto-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-container-repo-auto-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-mars-pulp-monitoring
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-mars-pulp-monitoring
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-wrapper-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-wrapper-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-wrapper-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-wrapper-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-gutentag
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-gutentag-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-gutentag-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-mars-automars
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-mars-automars
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ai.ingest
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ai.ingest
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-find-missing-sources
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-find-missing-sources
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-bz-ldap-group-sync-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-bz-ldap-group-sync-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-bz-ldap-group-sync-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-bz-ldap-group-sync-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-aicoeactivity-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-aicoeactivity-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-clair-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresevents-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cyborg-regidoresevents-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoreshangout-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cyborg-regidoreshangout-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidorestrello-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cyborg-regidorestrello-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresjira-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cyborg-regidoresjira-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresgitlab-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cyborg-regidoresgitlab-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidores-github-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cyborg-regidores-github-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-intern-bootcamp
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-intern-bootcamp
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-intern-answers
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-intern-answers
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ludus-events-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-ludus-events-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ai.stage.ingest
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ai.stage.ingest
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cnv
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cnv
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-vitals
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-vitals
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-rhel8-prp-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-rhel8-prp-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-rhel8-prp-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-rhel8-prp-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-greenwave-anomaly-detect
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-greenwave-anomaly-detect
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-dev-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: pnc-dev-logs-input
+  config:
+    retention.ms: 864000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-dev-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: pnc-dev-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-stage-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: pnc-stage-logs-input
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-stage-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: pnc-stage-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: pnc-logs-input
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: pnc-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-tower-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-tower-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-tower-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-tower-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-dh-grafana-anomaly-detect
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-dh-grafana-anomaly-detect
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-snitch-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-snitch-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-snitch-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnt-devops-snitch-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccit-data-integrator-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ccit-data-integrator-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 1
+  topicName: ccx-dev-insights-operator-archive-new
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 1
+  topicName: ccx-dev-insights-operator-archive-synced
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ccx-dev-insights-operator-archive-rules-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 4
+  replicas: 1
+  topicName: ccx-dev-insights-operator-archive-features
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 1
+  topicName: ccx-qa-insights-operator-archive-new
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 1
+  topicName: ccx-qa-insights-operator-archive-synced
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ccx-qa-insights-operator-archive-rules-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ccx-qa-insights-operator-archive-features
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 1
+  topicName: ccx-prod-insights-operator-archive-new
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 1
+  topicName: ccx-prod-insights-operator-archive-synced
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ccx-prod-insights-operator-archive-rules-results
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: ccx-prod-insights-operator-archive-features
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-tft
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-tft
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-honeybadger
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-honeybadger
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-ccx-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-ccx-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-ccx-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: ccx-dev-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: ccx-dev-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: ccx-qa-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: ccx-qa-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: ccx-prod-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: ccx-prod-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-sysops-ansible-tower
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-sysops-ansible-tower
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-umb
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-umb
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-fluentd
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 30
+  replicas: 1
+  topicName: dynamic-fluentd
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-rsyslog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 30
+  replicas: 1
+  topicName: dynamic-rsyslog
+  config:
+    retention.bytes: 48318357341
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-logstash
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-logstash
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-prodsec-dev-sdengine-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-prodsec-dev-sdengine-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-prodsec-dev-sdengine-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-exd-meteor
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-exd-meteor
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cnv-qe-testing
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cnv-qe-testing
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-expunge
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-expunge
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cloud-governance-index
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-cloud-governance-index
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-assisted-service-events
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-assisted-service-events
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-stage-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-green-stage-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-stage-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-green-stage-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-green-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-green-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-devel-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-green-devel-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-devel-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-green-devel-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-stage-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnc-green-stage-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnc-green-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-devel-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-pnc-green-devel-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-kni-qe-ci-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-kni-qe-ci-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-data
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-kni-qe-ci-data
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-ipi
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-kni-qe-ci-ipi
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-testrun-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-kni-qe-ci-testrun-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-dashboard
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: dynamic-kni-qe-ci-dashboard
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-prod-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: log-event-duration-prod-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-devel-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: log-event-duration-devel-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-green-stage-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: log-event-duration-green-stage-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-prod-v3-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: log-event-duration-prod-v3-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-stage-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 1
+  topicName: log-event-duration-stage-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-master
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-notifications-master
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stable-next
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-notifications-stable-next
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stable-current
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-notifications-stable-current
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-notifications-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 1
+  topicName: pnc-notifications-prod

--- a/kfdefs/overlays/dev/dh-dev-message-bus/kustomization.yaml
+++ b/kfdefs/overlays/dev/dh-dev-message-bus/kustomization.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: dh-dev-message-bus
 
 resources:
-  - dh-stage-trino
-  - dh-stage-superset
-  - dh-stage-message-bus
+  - ../../../base/kafka
+  - ./kafka-topics.yaml

--- a/kfdefs/overlays/dev/kustomization.yaml
+++ b/kfdefs/overlays/dev/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - dh-dev-trino
   - dh-dev-superset
+  - dh-dev-message-bus

--- a/kfdefs/overlays/prod/dh-prod-message-bus/kafka-cluster.yaml
+++ b/kfdefs/overlays/prod/dh-prod-message-bus/kafka-cluster.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: "three"
+spec:
+  kafka:
+    readinessProbe:
+      initialDelaySeconds: 175
+    livenessProbe:
+      initialDelaySeconds: 175
+    template:
+      pod:
+        affinity:
+          # We do not want the Kafka nodes to run on our Baremetal Elasticsearch
+          # nodes. See http://strimzi.io/docs/0.8.1/#assembly-scheduling-deployment-configuration-kafka-connect
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                  - key: "provider"
+                    operator: In
+                    values:
+                      - "gpu-baremetal"
+    replicas: 5
+    config:
+      offsets.topic.replication.factor: 5
+      transaction.state.log.min.isr: 2
+      min.insync.replicas: 2
+      default.replication.factor: 5
+    storage:
+      size: "3000Gi"
+      class: "ceph-dyn-datahub-prod-psi"
+  zookeeper:
+    replicas: 3
+    storage:
+      class: "ceph-dyn-datahub-prod-psi"

--- a/kfdefs/overlays/prod/dh-prod-message-bus/kafka-topics.yaml
+++ b/kfdefs/overlays/prod/dh-prod-message-bus/kafka-topics.yaml
@@ -1,0 +1,1515 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.pipeline
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ciumb.trans20180907.cvp.pipeline
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ciumb.trans20180907.cvp.stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ciumb.trans20180907.cvp.test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.non-cvp
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ciumb.trans20180907.non-cvp
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dh-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dh-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: fedmsg.production
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: fedmsg.production
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.logstash
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ingest.logstash
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.rsyslog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 10
+  replicas: 5
+  topicName: ingest.rsyslog
+  config:
+    retention.ms: 86400000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: quayingest.prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: quayingest.prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-shipshift-prod-logs-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 14
+  replicas: 5
+  topicName: dynamic-shipshift-prod-logs-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: umbingest.prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: umbingest.prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-radas
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-radas
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-3sn-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-3sn-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-3sn-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-3sn-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccit-lfa-alpha
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-ccit-lfa-alpha
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: dynamic-pnc-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-stage-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: dynamic-pnc-stage-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-dev-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: dynamic-pnc-dev-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-indy-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 20
+  replicas: 5
+  topicName: dynamic-indy-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-metaxor-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-metaxor-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-metaxor-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-metaxor-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 14
+  replicas: 5
+  topicName: dynamic-quay-io-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-staging
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 6
+  replicas: 5
+  topicName: dynamic-quay-io-staging
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-testing
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-quay-io-testing
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-container-repo-auto-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-container-repo-auto-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-container-repo-auto-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-container-repo-auto-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-mars-pulp-monitoring
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-mars-pulp-monitoring
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-wrapper-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-wrapper-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-wrapper-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-wrapper-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-gutentag
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-gutentag-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-gutentag-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-mars-automars
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-mars-automars
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ai.ingest
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ai.ingest
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-find-missing-sources
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-find-missing-sources
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-bz-ldap-group-sync-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-bz-ldap-group-sync-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-bz-ldap-group-sync-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-bz-ldap-group-sync-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-aicoeactivity-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-aicoeactivity-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-clair-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresevents-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cyborg-regidoresevents-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoreshangout-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cyborg-regidoreshangout-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidorestrello-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cyborg-regidorestrello-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresjira-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cyborg-regidoresjira-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresgitlab-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cyborg-regidoresgitlab-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidores-github-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cyborg-regidores-github-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-intern-bootcamp
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-intern-bootcamp
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-intern-answers
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-intern-answers
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ludus-events-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-ludus-events-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ai.stage.ingest
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ai.stage.ingest
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cnv
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cnv
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-vitals
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-vitals
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-rhel8-prp-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-rhel8-prp-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-rhel8-prp-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-rhel8-prp-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-greenwave-anomaly-detect
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-greenwave-anomaly-detect
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-dev-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: pnc-dev-logs-input
+  config:
+    retention.ms: 864000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-dev-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: pnc-dev-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-stage-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: pnc-stage-logs-input
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-stage-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: pnc-stage-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: pnc-logs-input
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: pnc-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-tower-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-tower-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-tower-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-tower-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-dh-grafana-anomaly-detect
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-dh-grafana-anomaly-detect
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-snitch-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-snitch-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-snitch-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnt-devops-snitch-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccit-data-integrator-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ccit-data-integrator-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 5
+  topicName: ccx-dev-insights-operator-archive-new
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 5
+  topicName: ccx-dev-insights-operator-archive-synced
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ccx-dev-insights-operator-archive-rules-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 4
+  replicas: 5
+  topicName: ccx-dev-insights-operator-archive-features
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 5
+  topicName: ccx-qa-insights-operator-archive-new
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 5
+  topicName: ccx-qa-insights-operator-archive-synced
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ccx-qa-insights-operator-archive-rules-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ccx-qa-insights-operator-archive-features
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 5
+  topicName: ccx-prod-insights-operator-archive-new
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 5
+  topicName: ccx-prod-insights-operator-archive-synced
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ccx-prod-insights-operator-archive-rules-results
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: ccx-prod-insights-operator-archive-features
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-tft
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-tft
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-honeybadger
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-honeybadger
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-ccx-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-ccx-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-ccx-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: ccx-dev-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: ccx-dev-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: ccx-qa-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: ccx-qa-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: ccx-prod-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: ccx-prod-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-sysops-ansible-tower
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-sysops-ansible-tower
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-umb
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-umb
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-rsyslog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 30
+  replicas: 5
+  topicName: dynamic-rsyslog
+  config:
+    retention.bytes: 48318357341
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-logstash
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-logstash
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-prodsec-dev-sdengine-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-prodsec-dev-sdengine-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-prodsec-dev-sdengine-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-exd-meteor
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-exd-meteor
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cnv-qe-testing
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cnv-qe-testing
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-expunge
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-expunge
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cloud-governance-index
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-cloud-governance-index
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-assisted-service-events
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-assisted-service-events
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-stage-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-green-stage-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-stage-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-green-stage-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-green-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-green-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-devel-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-green-devel-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-devel-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-green-devel-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-stage-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnc-green-stage-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnc-green-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-devel-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-pnc-green-devel-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-kni-qe-ci-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-kni-qe-ci-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-data
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-kni-qe-ci-data
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-ipi
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-kni-qe-ci-ipi
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-testrun-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-kni-qe-ci-testrun-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-dashboard
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: dynamic-kni-qe-ci-dashboard
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-prod-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: log-event-duration-prod-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-devel-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: log-event-duration-devel-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-green-stage-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: log-event-duration-green-stage-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-prod-v3-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: log-event-duration-prod-v3-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-stage-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 5
+  topicName: log-event-duration-stage-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-master
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-notifications-master
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stable-next
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-notifications-stable-next
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stable-current
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-notifications-stable-current
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-notifications-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 5
+  topicName: pnc-notifications-prod

--- a/kfdefs/overlays/prod/dh-prod-message-bus/kustomization.yaml
+++ b/kfdefs/overlays/prod/dh-prod-message-bus/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dh-prod-message-bus
+
+resources:
+  - ../../../base/kafka
+  - ./kafka-topics.yaml
+
+patchesStrategicMerge:
+  - ./kafka-cluster.yaml

--- a/kfdefs/overlays/prod/kustomization.yaml
+++ b/kfdefs/overlays/prod/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - dh-prod-trino
   - dh-prod-superset
+  - dh-prod-message-bus

--- a/kfdefs/overlays/stage/dh-stage-message-bus/kafka-cluster.yaml
+++ b/kfdefs/overlays/stage/dh-stage-message-bus/kafka-cluster.yaml
@@ -1,0 +1,26 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: "three"
+spec:
+  kafkaExporter: {}
+  kafka:
+    template:
+      pod:
+        tolerations: null
+        affinity: null
+    replicas: 3
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      min.insync.replicas: 2
+      default.replication.factor: 3
+
+    storage:
+      size: "5Gi"
+      class: ""
+  zookeeper:
+    replicas: 3
+    storage:
+      size: "5Gi"
+      class: ""

--- a/kfdefs/overlays/stage/dh-stage-message-bus/kafka-topics.yaml
+++ b/kfdefs/overlays/stage/dh-stage-message-bus/kafka-topics.yaml
@@ -1,0 +1,1539 @@
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.pipeline
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ciumb.trans20180907.cvp.pipeline
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ciumb.trans20180907.cvp.stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.cvp.test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ciumb.trans20180907.cvp.test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ciumb.trans20180907.non-cvp
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ciumb.trans20180907.non-cvp
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dh-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dh-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: fedmsg.production
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: fedmsg.production
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.fluentd
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ingest.fluentd
+  config:
+    retention.ms: 86400000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.logstash
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ingest.logstash
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ingest.rsyslog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 10
+  replicas: 3
+  topicName: ingest.rsyslog
+  config:
+    retention.ms: 86400000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: quayingest.prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: quayingest.prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-shipshift-prod-logs-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 14
+  replicas: 3
+  topicName: dynamic-shipshift-prod-logs-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: umbingest.prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: umbingest.prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-radas
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-radas
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-3sn-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-3sn-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-3sn-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-3sn-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccit-lfa-alpha
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-ccit-lfa-alpha
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: dynamic-pnc-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-stage-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: dynamic-pnc-stage-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-dev-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: dynamic-pnc-dev-logs
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-indy-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 20
+  replicas: 3
+  topicName: dynamic-indy-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-metaxor-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-metaxor-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-metaxor-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-metaxor-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-metaxor-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 14
+  replicas: 3
+  topicName: dynamic-quay-io-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-staging
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 6
+  replicas: 3
+  topicName: dynamic-quay-io-staging
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-quay-io-testing
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-quay-io-testing
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-container-repo-auto-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-container-repo-auto-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-container-repo-auto-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-container-repo-auto-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-mars-pulp-monitoring
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-mars-pulp-monitoring
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-wrapper-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-wrapper-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-wrapper-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-wrapper-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-wrapper-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-gutentag
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-gutentag-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-gutentag-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-gutentag-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-mars-automars
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-mars-automars
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ai.ingest
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ai.ingest
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-find-missing-sources
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-find-missing-sources
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-bz-ldap-group-sync-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-bz-ldap-group-sync-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-bz-ldap-group-sync-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-bz-ldap-group-sync-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-aicoeactivity-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-aicoeactivity-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-clair-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-clair-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresevents-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cyborg-regidoresevents-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoreshangout-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cyborg-regidoreshangout-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidorestrello-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cyborg-regidorestrello-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresjira-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cyborg-regidoresjira-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidoresgitlab-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cyborg-regidoresgitlab-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cyborg-regidores-github-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cyborg-regidores-github-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-intern-bootcamp
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-intern-bootcamp
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-intern-answers
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-intern-answers
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ludus-events-ingest-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-ludus-events-ingest-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ai.stage.ingest
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ai.stage.ingest
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cnv
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cnv
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-vitals
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-vitals
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-rhel8-prp-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-rhel8-prp-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-rhel8-prp-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-rhel8-prp-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-greenwave-anomaly-detect
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-greenwave-anomaly-detect
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-dev-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: pnc-dev-logs-input
+  config:
+    retention.ms: 864000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-dev-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: pnc-dev-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-stage-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: pnc-stage-logs-input
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-stage-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: pnc-stage-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: pnc-logs-input
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-logs-db-out
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: pnc-logs-db-out
+  config:
+    retention.ms: 2592000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-tower-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-tower-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-tower-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-tower-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-dh-grafana-anomaly-detect
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-dh-grafana-anomaly-detect
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-snitch-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-snitch-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-snitch-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnt-devops-snitch-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnt-devops-snitch-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccit-data-integrator-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ccit-data-integrator-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 3
+  topicName: ccx-dev-insights-operator-archive-new
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 3
+  topicName: ccx-dev-insights-operator-archive-synced
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ccx-dev-insights-operator-archive-rules-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 4
+  replicas: 3
+  topicName: ccx-dev-insights-operator-archive-features
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 3
+  topicName: ccx-qa-insights-operator-archive-new
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 3
+  topicName: ccx-qa-insights-operator-archive-synced
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ccx-qa-insights-operator-archive-rules-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ccx-qa-insights-operator-archive-features
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-new
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 3
+  topicName: ccx-prod-insights-operator-archive-new
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-synced
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 8
+  replicas: 3
+  topicName: ccx-prod-insights-operator-archive-synced
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-rules-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ccx-prod-insights-operator-archive-rules-results
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-insights-operator-archive-features
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: ccx-prod-insights-operator-archive-features
+  config:
+    retention.ms: 432000000
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-tft
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-tft
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-honeybadger
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-honeybadger
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-ccx-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-qa
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-ccx-qa
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-ccx-dev
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-ccx-dev
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: ccx-dev-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-dev-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: ccx-dev-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: ccx-qa-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-qa-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: ccx-qa-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-rule-nomination-process
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: ccx-prod-rule-nomination-process
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: ccx-prod-rule-nomination-update
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: ccx-prod-rule-nomination-update
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-sysops-ansible-tower
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-sysops-ansible-tower
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-umb
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-umb
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-fluentd
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 30
+  replicas: 3
+  topicName: dynamic-fluentd
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-rsyslog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 30
+  replicas: 3
+  topicName: dynamic-rsyslog
+  config:
+    retention.bytes: 48318357341
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-logstash
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-logstash
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-prodsec-dev-sdengine-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-prodsec-dev-sdengine-prod
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-prodsec-dev-sdengine-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-prodsec-dev-sdengine-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-exd-meteor
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-exd-meteor
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cnv-qe-testing
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cnv-qe-testing
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-expunge
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-expunge
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-cloud-governance-index
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-cloud-governance-index
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-assisted-service-events
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-assisted-service-events
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-stage-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-green-stage-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-stage-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-green-stage-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-green-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-green-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-devel-logs-input
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-green-devel-logs-input
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-green-devel-logs-db-output
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-green-devel-logs-db-output
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-stage-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnc-green-stage-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnc-green-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-pnc-green-devel-logs
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-pnc-green-devel-logs
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-kni-qe-ci-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-test
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-kni-qe-ci-test
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-data
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-kni-qe-ci-data
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-ipi
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-kni-qe-ci-ipi
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-testrun-results
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-kni-qe-ci-testrun-results
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: dynamic-kni-qe-ci-dashboard
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: dynamic-kni-qe-ci-dashboard
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-prod-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: log-event-duration-prod-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-devel-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: log-event-duration-devel-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-green-stage-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: log-event-duration-green-stage-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-prod-v3-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: log-event-duration-prod-v3-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: log-event-duration-stage-v2-log-store-changelog
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 1
+  replicas: 3
+  topicName: log-event-duration-stage-v2-log-store-changelog
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-master
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-notifications-master
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stable-next
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-notifications-stable-next
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stable-current
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-notifications-stable-current
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-stage
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-notifications-stage
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: pnc-notifications-prod
+  labels:
+    strimzi.io/cluster: three
+spec:
+  partitions: 2
+  replicas: 3
+  topicName: pnc-notifications-prod

--- a/kfdefs/overlays/stage/dh-stage-message-bus/kustomization.yaml
+++ b/kfdefs/overlays/stage/dh-stage-message-bus/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dh-stage-message-bus
+
+resources:
+  - ../../../base/kafka
+  - ./kafka-topics.yaml
+
+patchesStrategicMerge:
+  - ./kafka-cluster.yaml

--- a/yamllint-config.yaml
+++ b/yamllint-config.yaml
@@ -1,5 +1,7 @@
 ---
 extends: default
+ignore: |
+  templates/
 rules:
   line-length: disable
   document-start: disable


### PR DESCRIPTION
As part of this PR, we have made some updates to allow kafka to work on
OCP4

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>