### PR TITLE
Update kustomize base for superset

### DIFF
--- a/kfdefs/base/superset/kustomization.yaml
+++ b/kfdefs/base/superset/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 namespace: idh-superset
 
 bases:
-  - github.com/opendatahub-io/odh-manifests/superset/base?ref=2aeb0165372a2b87a7c97ddb37462c8ff40f4185
+  - github.com/opendatahub-io/odh-manifests/superset/base?ref=42c1a674900b38a002a5c6c43904abfa582ef072
 
 patchesStrategicMerge:
   - ./superset-deployment.yaml


### PR DESCRIPTION
This updates our superset deployment base to pull from ODH latest. The
significant diff here is upgrading superset from 1.3.0 to 1.3.2