### PR TITLE
Update RHODS to 1.5.0-7 with custom index image

### DIFF
--- a/rhods/catalog-source/overlays/dev/catalog-source.yaml
+++ b/rhods/catalog-source/overlays/dev/catalog-source.yaml
@@ -3,4 +3,4 @@ kind: CatalogSource
 metadata:
   name: addon-managed-odh-catalog
 spec:
-  image: quay.io/modh/qe-catalog-source:v150-7
+  image: quay.io/modh/qe-catalog-source:v1507-140-upgrade

--- a/rhods/catalog-source/overlays/production/catalog-source.yaml
+++ b/rhods/catalog-source/overlays/production/catalog-source.yaml
@@ -3,4 +3,4 @@ kind: CatalogSource
 metadata:
   name: addon-managed-odh-catalog
 spec:
-  image: quay.io/modh/qe-catalog-source:v150-7
+  image: quay.io/modh/qe-catalog-source:v1507-140-upgrade

--- a/rhods/catalog-source/overlays/stage/catalog-source.yaml
+++ b/rhods/catalog-source/overlays/stage/catalog-source.yaml
@@ -3,4 +3,4 @@ kind: CatalogSource
 metadata:
   name: addon-managed-odh-catalog
 spec:
-  image: quay.io/modh/qe-catalog-source:v150-7
+  image: quay.io/modh/qe-catalog-source:v1507-140-upgrade


### PR DESCRIPTION
We erroneously upgraded RHODS to 1.4.0-2 at some point in the past. It
is not part of any supported upgrade paths. I've currently generated a
custom index image to get us from 1.4.0-2 to 1.5.0-7. With the next
RHODS release we should be able to use the "normal" index images.

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>
