### PR TITLE
Rearrange Obslytics Small Metric Parallism

### DIFF
--- a/obslytics/bases/workflow-templates.yaml
+++ b/obslytics/bases/workflow-templates.yaml
@@ -611,7 +611,7 @@ spec:
 
     # The same as the regular backfill-metric template, but with 6x timestamp parallelism
     - name: backfill-small-metric
-      parallelism: 6
+      parallelism: 3
       inputs:
         parameters:
           - name: backfill_count

--- a/obslytics/overlays/ocp4-migration/triggers.yaml
+++ b/obslytics/overlays/ocp4-migration/triggers.yaml
@@ -352,7 +352,7 @@
 
 - op: replace
   path: /spec/templates/1/parallelism
-  value: 20
+  value: 40
 
 - op: replace
   path: /spec/templates/2/parallelism


### PR DESCRIPTION
Run more metrics concurrently rather than more gaps of the same metric
This should help make resource utilization more efficient