### PR TITLE
Remove update strategy for s3-webserver deploymentconfig

### DIFF
--- a/s3-webserver/base/deploymentconfig.yaml
+++ b/s3-webserver/base/deploymentconfig.yaml
@@ -7,10 +7,6 @@ metadata:
     template: s3webserver
 spec:
   replicas: 1
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      minReadySeconds: 600
   template:
     metadata:
       name: s3webserver


### PR DESCRIPTION
ArgoCD didn't like this block in the app diff, and none of our other
deployment configs have this defined.