### PR TITLE
Add a blackbox probe for jupyterhub

### DIFF
--- a/monitoring/base/jupyterhub-blackbox-service-monitor.yaml
+++ b/monitoring/base/jupyterhub-blackbox-service-monitor.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: jupyterhub-blackbox-service-monitor
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - sourceLabels:
+            - __address__
+          targetLabel: __param_target
+        - sourceLabels:
+            - __param_target
+          targetLabel: instance
+        - replacement: 'https://jupyterhub.datahub.redhat.com/'
+          targetLabel: target
+      params:
+        module:
+          - http_2xx
+        target:
+          - 'https://jupyterhub.datahub.redhat.com/'
+      path: /probe
+      targetPort: 9115
+  jobLabel: prometheus.io/joblabel
+  namespaceSelector:
+    matchNames:
+      - dh-dev-monitoring
+      - dh-stage-monitoring
+      - dh-prod-monitoring
+  selector:
+    matchLabels:
+      prometheus.io/scrape: 'true'

--- a/monitoring/base/kustomization.yaml
+++ b/monitoring/base/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - datahub-help-blackbox-service-monitor.yaml
   - trino-blackbox-service-monitor.yaml
   - superset-blackbox-service-monitor.yaml
+  - jupyterhub-blackbox-service-monitor.yaml


### PR DESCRIPTION
This will migrate our probe for jupyterhub from the old to the new
monitoring stack, which means we'll benefit from the new multi burn
rate/multi window alerting rules, hopefully reducing alerting fatigue.