### PR TITLE
Adding minio dependencies required for KFP

### DIFF
--- a/kfp-tekton/overlays/dev/configmaps/kfp-tekton-config.yaml
+++ b/kfp-tekton/overlays/dev/configmaps/kfp-tekton-config.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+data:
+  apply_tekton_custom_resource: "true"
+  archive_logs: "false"
+  artifact_bucket: mlpipeline
+  artifact_endpoint: minio-service.kubeflow:9000
+  artifact_endpoint_scheme: http://
+  artifact_image: quay.io/thoth-station/document-sync-job:v0.1.0
+  artifact_script: |-
+    #!/usr/bin/env sh
+    push_artifact() {
+        if [ -f "$2" ]; then
+            tar -cvzf $1.tgz $2
+            aws s3 --endpoint ${ARTIFACT_ENDPOINT_SCHEME}${ARTIFACT_ENDPOINT} cp $1.tgz s3://$ARTIFACT_BUCKET/artifacts/$PIPELINERUN/$PIPELINETASK/$1.tgz
+        else
+            echo "$2 file does not exist. Skip artifact tracking for $1"
+        fi
+    }
+    push_log() {
+        cat /var/log/containers/$PODNAME*$NAMESPACE*step-main*.log > step-main.log
+        push_artifact main-log step-main.log
+    }
+    strip_eof() {
+        if [ -f "$2" ]; then
+            awk 'NF' $2 | head -c -1 > $1_temp_save && cp $1_temp_save $2
+        fi
+    }
+  inject_default_script: "true"
+  strip_eof: "true"
+  terminate_status: Cancelled
+  track_artifacts: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    application-crd-id: kubeflow-pipelines
+  name: kfp-tekton-config

--- a/kfp-tekton/overlays/dev/deployments/minio.yaml
+++ b/kfp-tekton/overlays/dev/deployments/minio.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: minio
+    application-crd-id: kubeflow-pipelines
+  name: minio
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: minio
+      application-crd-id: kubeflow-pipelines
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio
+        application-crd-id: kubeflow-pipelines
+    spec:
+      containers:
+      - args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: accesskey
+              name: mlpipeline-minio-artifact
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: mlpipeline-minio-artifact
+        image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+        imagePullPolicy: IfNotPresent
+        name: minio
+        ports:
+        - containerPort: 9000
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 20m
+            memory: 100Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data
+          name: data
+          subPath: minio
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: minio-pvc

--- a/kfp-tekton/overlays/dev/deployments/ml-pipeline-ui.yaml
+++ b/kfp-tekton/overlays/dev/deployments/ml-pipeline-ui.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-ui
+    application-crd-id: kubeflow-pipelines
+  name: ml-pipeline-ui
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ml-pipeline-ui
+      application-crd-id: kubeflow-pipelines
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-ui
+        application-crd-id: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+          value: /etc/config/viewer-pod-template.json
+        - name: MINIO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: accesskey
+              name: mlpipeline-minio-artifact
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: mlpipeline-minio-artifact
+        - name: ALLOW_CUSTOM_VISUALIZATIONS
+          value: "true"
+        - name: ARGO_ARCHIVE_LOGS
+          value: "true"
+        image: quay.io/internaldatahub/frontend:1.1.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:3000/apis/v1beta1/healthz
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: ml-pipeline-ui
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:3000/apis/v1beta1/healthz
+          failureThreshold: 3
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+            memory: 70Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: ml-pipeline-ui
+      serviceAccountName: ml-pipeline-ui
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: ml-pipeline-ui-configmap
+        name: config-volume

--- a/kfp-tekton/overlays/dev/kustomization.yaml
+++ b/kfp-tekton/overlays/dev/kustomization.yaml
@@ -5,3 +5,11 @@ namespace: dh-dev-kfp-tekton
 
 resources:
   - ../../base
+  - ./secrets/mlpipeline-minio-artifact.yaml
+  - ./deployments/minio.yaml
+  - ./persistentvolumeclaims/minio-pvc.yaml
+  - ./services/minio-service.yaml
+
+patchesStrategicMerge:
+  - ./configmaps/kfp-tekton-config.yaml
+  - ./deployments/ml-pipeline-ui.yaml

--- a/kfp-tekton/overlays/dev/persistentvolumeclaims/minio-pvc.yaml
+++ b/kfp-tekton/overlays/dev/persistentvolumeclaims/minio-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    application-crd-id: kubeflow-pipelines
+  name: minio-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce

--- a/kfp-tekton/overlays/dev/secrets/mlpipeline-minio-artifact.yaml
+++ b/kfp-tekton/overlays/dev/secrets/mlpipeline-minio-artifact.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  accesskey: MTIzNGVy
+  secretkey: MTIzNDU2Nzg5
+kind: Secret
+metadata:
+  labels:
+    application-crd-id: kubeflow-pipelines
+  name: mlpipeline-minio-artifact
+type: Opaque

--- a/kfp-tekton/overlays/dev/services/minio-service.yaml
+++ b/kfp-tekton/overlays/dev/services/minio-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    application-crd-id: kubeflow-pipelines
+  name: minio-service
+spec:
+  clusterIP: 172.30.164.196
+  clusterIPs:
+  - 172.30.164.196
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: minio
+    application-crd-id: kubeflow-pipelines
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
Pulled down YAMLs added/utilized on the following dev cluster:
https://console-openshift-console.apps.ddalvi-dev.dev.datahub.redhat.com/k8s/ns/kubeflow/deployments 
that we used to create a toy KubeFlow Pipeline.

