### PR TITLE
Add trino group for CCX access requests

### DIFF
--- a/kfdefs/base/trino/trino-config-secret.yaml
+++ b/kfdefs/base/trino/trino-config-secret.yaml
@@ -52,6 +52,8 @@ stringData:
     cost-management:chambrid,kholdawa,aberglun,mskarbek,hproctor,aaiken
     rhods:jdemoss,egranger,cchase,gmoutier
     assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil
+    ccx-datalake-access:erich
+    ccx-sensitive-datalake-access:erich
   access-control.properties: |-
     access-control.name=file
     security.config-file=/etc/trino/rules.json
@@ -63,7 +65,7 @@ stringData:
           "allow": "all"
         },
         {
-        "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|usir|openshift-analytics|telemetry|cost-management|assisted-lakers",
+        "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|usir|openshift-analytics|telemetry|cost-management|assisted-lakers|ccx-datalake-access|ccx-sensitive-datalake-access",
           "allow": "read-only"
         },
         {
@@ -153,12 +155,12 @@ stringData:
           "privileges": ["SELECT"]
         },
         {
-          "group": "ccx|assisted-lakers",
+          "group": "ccx|assisted-lakers|ccx-datalake-access",
           "schema": "ccx",
           "privileges": ["SELECT"]
         },
         {
-          "group": "ccx|assisted-lakers",
+          "group": "ccx|assisted-lakers|ccx-sensitive-datalake-access",
           "schema": "ccx_sensitive",
           "privileges": ["SELECT"]
         },


### PR DESCRIPTION
This adds two new groups in Trino: ccx-datalake-access and
ccx-sensitive-datalake-access, with access to the CCX and CCX_Sensitive
schemas, respectively. These are the same groups that we have defined in
Rover and that we use to manage access to the CCX Superset roles. This
should simplify the onboarding process for granting access to CCX data.