### PR TITLE
Add comment about group ownership of assisted-lakers for Trino and Superset

### DIFF
--- a/kfdefs/base/superset/superset_additional_config.py
+++ b/kfdefs/base/superset/superset_additional_config.py
@@ -35,7 +35,7 @@ AUTH_ROLES_MAPPING = {
           'ccx-pm': ['CCX Sensitive', 'CCX'],
           'ccx-datalake-access': ['CCX'],
           'ccx-sensitive-datalake-access': ['CCX', 'CCX Sensitive'],
-          'assisted-lakers': ['CCX', 'CCX Sensitive']
+          'assisted-lakers': ['CCX', 'CCX Sensitive'] # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
         }
 
 

--- a/kfdefs/base/trino/trino-config-secret.yaml
+++ b/kfdefs/base/trino/trino-config-secret.yaml
@@ -51,7 +51,7 @@ stringData:
     telemetry:ridubey,skamired,jenndavi,weaton,xinfli,cchase,egranger,cblum
     cost-management:chambrid,kholdawa,aberglun,mskarbek,hproctor,aaiken
     rhods:jdemoss,egranger,cchase,gmoutier
-    assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil
+    assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
     ccx-datalake-access:erich,aravindh
     ccx-sensitive-datalake-access:erich
   access-control.properties: |-


### PR DESCRIPTION
The CCX team requested that we make it super explicit that these
individuals own membership in these groups and are responsible for
maintaining it. This comment makes that clear.