### PR TITLE
Outage recovery:  Comment out active backfill metrics, remove retrySt…

### DIFF
--- a/obslytics/overlays/ocp4-migration/triggers.yaml
+++ b/obslytics/overlays/ocp4-migration/triggers.yaml
@@ -143,26 +143,26 @@
   path: /spec/templates/2/steps/0/0/withItems
   value:
     # TODO: rearrange in cron order once everything is fully backfilled
-    - backfill_to: 2020-02-01T00:00:00Z
-      name: cluster:usage:containers:sum
-    - backfill_to: 2020-11-01T00:00:00Z
-      name: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
-    - backfill_to: 2020-11-01T00:00:00Z
-      name: cluster:usage:workload:capacity_physical_cpu_cores:min:5m
-    - backfill_to: 2020-11-01T00:00:00Z
-      name: cluster:usage:workload:capacity_physical_cpu_core_seconds
-    - backfill_to: 2020-07-01T00:00:00Z
-      name: cluster_legacy_scheduler_policy
-    - backfill_to: 2020-08-01T00:00:00Z
-      name: olm_resolution_duration_seconds
-    - backfill_to: 2020-09-01T00:00:00Z
-      name: monitoring:container_memory_working_set_bytes:sum
-    - backfill_to: 2021-01-01T00:00:00Z
-      name: cluster:usage:workload:ingress_request_total:irate5m
-    - backfill_to: 2019-06-01T00:00:00Z
-      name: cluster:memory_usage_bytes:sum
-    - backfill_to: 2019-06-01T00:00:00Z
-      name: cluster_version_payload
+    # - backfill_to: 2020-02-01T00:00:00Z
+    #   name: cluster:usage:containers:sum
+    # - backfill_to: 2020-11-01T00:00:00Z
+    #   name: cluster:usage:workload:capacity_physical_cpu_cores:max:5m
+    # - backfill_to: 2020-11-01T00:00:00Z
+    #   name: cluster:usage:workload:capacity_physical_cpu_cores:min:5m
+    # - backfill_to: 2020-11-01T00:00:00Z
+    #   name: cluster:usage:workload:capacity_physical_cpu_core_seconds
+    # - backfill_to: 2020-07-01T00:00:00Z
+    #   name: cluster_legacy_scheduler_policy
+    # - backfill_to: 2020-08-01T00:00:00Z
+    #   name: olm_resolution_duration_seconds
+    # - backfill_to: 2020-09-01T00:00:00Z
+    #   name: monitoring:container_memory_working_set_bytes:sum
+    # - backfill_to: 2021-01-01T00:00:00Z
+    #   name: cluster:usage:workload:ingress_request_total:irate5m
+    # - backfill_to: 2019-06-01T00:00:00Z
+    #   name: cluster:memory_usage_bytes:sum
+    # - backfill_to: 2019-06-01T00:00:00Z
+    #   name: cluster_version_payload
 
     ##### HIGH PRIORITY #####
     - backfill_to: 2019-08-01T00:00:00Z

--- a/obslytics/overlays/ocp4-migration/workflow-templates.yaml
+++ b/obslytics/overlays/ocp4-migration/workflow-templates.yaml
@@ -41,7 +41,7 @@
 
 - op: replace
   path: /spec/templates/5/retryStrategy/limit
-  value: 1
+  value: 0
 
 - op: replace
   path: /spec/templates/5/script/image


### PR DESCRIPTION
…rategy

- retryStrategy no longer needed with Gap Detection and causes delays, set to 0
- new metrics will always be backfilling for a while, comment out while rest of
  metrics recover