### PR TITLE
Revert "Rever RHODS to version 1.9"

### DIFF
--- a/rhods/catalog-source/base/catalog-source.yaml
+++ b/rhods/catalog-source/base/catalog-source.yaml
@@ -4,7 +4,7 @@ metadata:
   name: addon-managed-odh-catalog
 spec:
   displayName: Managed Open Data Hub Operator
-  image: quay.io/modh/qe-catalog-source:v190-7
+  image: quay.io/modh/qe-catalog-source:v1100-6
   publisher: OSD Red Hat Addons
   sourceType: grpc
   secrets:


### PR DESCRIPTION
This reverts commit b7651e488284c425f027065e14f8691dab747d48.

The right way to revert RHODS versions is to "fail forward".