### PR TITLE
Add s3 sync job for IBM marketplace data

### DIFF
--- a/argo-workflows/base/secrets/marketplace2ibm-sync-secret.enc.yaml
+++ b/argo-workflows/base/secrets/marketplace2ibm-sync-secret.enc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: marketplace2ibm-sync
+stringData:
+    rclone.conf: ENC[AES256_GCM,data:ujE1e1EYeNwj7WoaFw39K5S7ip1bGoxQqyk0EgQCDckhOyWq5HpMhq7DeVTlZSXvFS404fJf+Ojyf2l4FpWyHHs3bcZAW9CldPmQWV9FkoCn2dPV+6GnkC5UtVc+f98sipoAlkIRu1z3wIdLSJmviBdLm5eIxA9pEG3KOnRisqUPgB2ym/bKbeKUdaCXTim3ltIrQMupC3vJN6oRbEOrMjlsZub2tm7LSNuqmWyc7QNVvoaXH4DguaBjl9VApGhL+zI/giPOd+C7JmyQaWIIG6qnrGZbPzQVgH2Gp9Om492EBWFPq4F8j2ylF6ebXLuoNo8S1CUkc/XmOcHl0SsVQLtxr8/u3QwPn9N0Mn/m8yBp+Fca93y5Zj1lCXQ/aDVKSk/reJA0H1Yhra8hQoAmF2eL2hL+WtEFNa9WHFaZDd1b8SpcOhHIPlNeN230l1R1QspJoUBOSDPlEiBktRmCu7ElLZFeon7lPB2qKJYg8+s2fJf5/eClNYtfDiC0APZqqY2AtP+aPXkdZBbObtaB6XYz2sw65jbUFomvBIKbzejeQ3VMAu4=,iv:iiSvG+MMCnPwYzeqYs4MF2kAp294x30O7aM4gfzu7/g=,tag:7b2yTS6fseUuNaG2HfxR6A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2022-05-06T20:04:50Z'
+    mac: ENC[AES256_GCM,data:QbvsbDYxwypTDa0oTz4SkukocmpJBBSSwPTitKMjns7t3Libcduz6AvZNjyXDLhjMAyUii6CZ65f73L1MnmYT/xdpRP5MiCVzArxGxRGUDf3sE8Bl+yxzWRzkBZmFVezRgcDCDTpKNBFd/jWArcPwp8KEDkRQn20HFE2Hi7aJ/o=,iv:AwxKccXAHkRd8Gc35phopDme+//lVszXkFPFnKAGCuE=,tag:tr8ejr09BDrPluaC83jxLA==,type:str]
+    pgp:
+    -   created_at: '2022-05-06T20:04:50Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQELA/irrHa183bxAQf3Wt1BqEbTscw4Vqz70LqwrZe/tBTDME2OFmdgcrUL/11b
+            jnrmGtXb+Cesc2JaemvDGZasvBYNTqOv/IZnbNPOYHgDCQvTl+2I4ELtDf9WUcd3
+            kiQ9u+pxTQoQXBOpBY1DiE9GY3GK8+10OtfrxLDUGS8tycs9wd1wgkSajZ6exNhz
+            Ayh+rBEvuk8ZH07VkyhI9XLtq7ELFqAB1+ZjHqSVhNaBY+VGOq1EstVbz6LneeqK
+            /NZnStK3uPWFd0mApRXKHcHjJA2nKuawr5q3pOSp7mIXdLrhrapRKs9GUHjeVNZp
+            RCnKtZTyJf7QL8s1cQE1IAR13Mi+rckK+MuxrHox0l4BjVGM6PyMjdLPp2kU4n2g
+            w61oEuLhDhB9UY0AIoUTEWIlK2pDc7xlVXJt20mAixVMOQiZRMSi1AnTMwzjIpzl
+            uHzuEv1QdXffvTWLSvHshFdgk6ZwSG0tQsNuY8a3
+            =gIhm
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.6.1

--- a/argo-workflows/base/secrets/marketplace2psi-sync-secret.enc.yaml
+++ b/argo-workflows/base/secrets/marketplace2psi-sync-secret.enc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: marketplace2psi-sync
+stringData:
+    rclone.conf: ENC[AES256_GCM,data:gTcFgl4nweRWCJVRcRb112CqBnBIqHO82wCwIHs2WLicp2pxKgPuqxN0JmYf3FC5YqxYMiLEHpOLrU64IOOo2am4P+i31/Z+diLF8g9Ok3d7A2wJUOMz5UqJ4NUFnJmWCkhHOZERANU9WKFHxne+f20Z4TCocVmEytV+MKDFQAu+F4AmJKM2s+hhA0OhEX19wF8R+tS6TAMNWQ1fiM3ZFgUyiVOlG0yKvP8hGmsKkikhRzd9r/rZeN8f3Unbco5vCOpdz+CzGo8060h6CxQnGYuWluPiQK6o9zYgPsEmtRHj60qoYG7HW0PEdIRWMOfM8xDyYDw4/r62CZQFZzM6HTFADBPgEGliOg7uUtAfZjEklwiFSdL2PT6Xuz2/YB85oYDfCZbZQAYf0oOSEVFlKFBrWGV+KxqP/3G3P6ojowYod2657OB4BCIIO46pxR3lkvwhQtYPpH6DlnI9cXwX39YLhEQ/vrdfJ/pAjzL31ZZWFjqpo1Ro,iv:RuuyVcxPQKcRtTeYMKKwAh/DbfmRvSYNycS4VsyAy3Y=,tag:XMQNAV47QdJ8U9EXfuB+kQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2022-05-06T19:49:45Z'
+    mac: ENC[AES256_GCM,data:EzpWy+XoKzWLOmFJyONP7Wof2ZoVqBv2lWQ1KBaTsX52fA1hl5tolMjBU9kYC8+LIphK2FPP2f6Gn/DujUFwaSwL7aBI9ycZXaSiRNgC7xR+BUm1o9C6+QfduzxigEY7W99rn7uWJ+4ErEqqRq+zFMiXTVNg0lZYjOS9rdrgjak=,iv:9RTIPqHLlhN9CtzvfShJbM2AG9GejKsabD1ilhRO2Z0=,tag:XMsBe5zJpOOlTE/B+Tjr0g==,type:str]
+    pgp:
+    -   created_at: '2022-05-06T19:49:45Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQELA/irrHa183bxAQf49hi/qfubjPWInrfKN9ANCgsCgN8kaV2ODyNH71KRb1+N
+            wJef4dZX7jIM3pDs2j/qKzfQuAn28+LW4yEEM9PSpTOvNe5vW+MjQJJbhWBPbyBV
+            iui+piB44vh2NhjwHAl6EyY4V9R3CCG/Gvi91aCOZenK6EeJrglIfzDBzGy4pm9h
+            G9RZELsKo/ZD6Up2oh4d8rJ9A8hCT0CXDCwyJDTKoKPjyRb3W8xbecBf3uZxfMYJ
+            IF1BTncYj2FZSeJ/2ztw56+0wjqP2lXC9p7pHdN1jAGdq9LSjRMIgBSkmhqIivY0
+            0Lu87gn6JB+BRKadoK26gV4wrcNeoPn5m8ppmsC80lwB0i0//a38TK4idl/jN54x
+            Kgg3wrvWbOFd3Wep8dFPkvxLtP9wbVuU7eow/Z+yK3j6Ho3VlowsqJRv+AMIJra8
+            7sHoH6rZ2dsfgOR3xJx/GEBSXARq78BXsYxCow==
+            =bSBH
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.6.1

--- a/argo-workflows/base/secrets/secret-generator.yaml
+++ b/argo-workflows/base/secrets/secret-generator.yaml
@@ -9,3 +9,5 @@ files:
   - ./secrets/rhods-usage-metrics-sync-secret.enc.yaml
   - ./secrets/floorist-sync-secret.enc.yaml
   - ./secrets/cost-management-sync-secret.enc.yaml
+  - ./secrets/marketplace2psi-sync-secret.enc.yaml
+  - ./secrets/marketplace2ibm-sync-secret.enc.yaml

--- a/argo-workflows/overlays/prod/backup-cron-workflows/kustomization.yaml
+++ b/argo-workflows/overlays/prod/backup-cron-workflows/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - s3-sync-rhods-usage-metrics-dev-cron-workflow.yaml
   - s3-sync-floorist-cron-workflow.yaml
   - s3-sync-cost-management-cron-workflow.yaml
+  - s3-sync-markeplace2psi-cron-workflow.yaml
+  - s3-sync-markeplace2ibm-cron-workflow.yaml

--- a/argo-workflows/overlays/prod/backup-cron-workflows/s3-sync-markeplace2ibm-cron-workflow.yaml
+++ b/argo-workflows/overlays/prod/backup-cron-workflows/s3-sync-markeplace2ibm-cron-workflow.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  generateName: s3-sync-marketplace2ibm-
+  name: s3-sync-marketplace2ibm
+spec:
+  schedule: "0 H * * *"
+  concurrencyPolicy: "Replace"
+  workflowSpec:
+    arguments:
+      parameters:
+        - name: sync_config
+          value: marketplace2ibm-sync
+        - name: src_bucket
+          value: open-marketplace-prod
+        - name: dest_bucket
+          value: rhm-metering-cos-bucket
+        - name: alerts_to
+          value: data-hub-alerts@redhat.com
+    workflowTemplateRef:
+      name: s3-backup

--- a/argo-workflows/overlays/prod/backup-cron-workflows/s3-sync-markeplace2psi-cron-workflow.yaml
+++ b/argo-workflows/overlays/prod/backup-cron-workflows/s3-sync-markeplace2psi-cron-workflow.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  generateName: s3-sync-marketplace2psi-
+  name: s3-sync-marketplace2psi
+spec:
+  schedule: "0 H * * *"
+  concurrencyPolicy: "Replace"
+  workflowSpec:
+    arguments:
+      parameters:
+        - name: sync_config
+          value: marketplace2psi-sync
+        - name: src_bucket
+          value: open-marketplace-prod
+        - name: dest_bucket
+          value: DH-SECURE-MARKETPLACE-METERING/production_data
+        - name: alerts_to
+          value: data-hub-alerts@redhat.com
+    workflowTemplateRef:
+      name: s3-backup


### PR DESCRIPTION
This needs to go to both PSI S3 and IBM S3, so it's two seprate sync
jobs.