### PR TITLE
Add special access to Superset and Trino systems

### DIFF
--- a/kfdefs/base/superset/superset_additional_config.py
+++ b/kfdefs/base/superset/superset_additional_config.py
@@ -35,7 +35,10 @@ AUTH_ROLES_MAPPING = {
           'ccx-pm': ['CCX Sensitive', 'CCX'],
           'ccx-datalake-access': ['CCX'],
           'ccx-sensitive-datalake-access': ['CCX', 'CCX Sensitive'],
-          'assisted-lakers': ['CCX', 'CCX Sensitive'] # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
+          'assisted-lakers': ['CCX', 'CCX Sensitive'], # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
+          'cide-insights': ['CIDE', 'CIDE Digests', 'CIDE Warehouse'],
+          'cide-digests-dashboard-access': ['CIDE Digests'],
+          'cide-warehouse-dashboard-access': ['CIDE Warehouse']
         }
 
 

--- a/kfdefs/base/trino/trino-config-secret.yaml
+++ b/kfdefs/base/trino/trino-config-secret.yaml
@@ -34,6 +34,7 @@ stringData:
     trino-admin:$2y$10$l9G7GLksnvOSGtM7av9Ja.g3oIO4HgYi3yFhKQz0YFLMy/itp4qLq
     ccx-admin:$2y$10$W0f2bKyu4Lhwulo7WOVm2uJr47sE.i5Z6vdZ4v6oXkD45VrgFyhaq
     eda-admin:$2y$10$LIOzHZmINThWXCRqC1IkF.4VhNn691cNf9eXOnsUKhDGePmjQsNRS
+    telemetry-automated:$2y$10$A8El86e9WbvaPeT8RB7zCusBo/cZg8n6Uk.teWRk9ku/apFC3asEG
   group-provider.properties: |-
     group-provider.name=file
     file.group-file=/etc/trino/group-mapping.properties
@@ -49,12 +50,15 @@ stringData:
     ansible-engineering:lsmola
     usir:sperkins,wpinheir,bcourt,khowell,pgoti
     openshift-analytics:rzalavad
-    telemetry:ridubey,skamired,jenndavi,weaton,xinfli,cchase,egranger,cblum
+    telemetry:ridubey,skamired,jenndavi,weaton,xinfli,cchase,egranger,cblum,telemetry-automated
     cost-management:chambrid,kholdawa,aberglun,mskarbek,hproctor,aaiken
     rhods:jdemoss,egranger,cchase,gmoutier
     assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
     ccx-datalake-access:erich,aravindh,akoshlak,wabuahma,kfyfe
     ccx-sensitive-datalake-access:erich,kfyfe,akoshlak
+    assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil,telemetry-automated # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
+    ccx-datalake-access:erich,aravindh,akoshlak,wabuahma
+    ccx-sensitive-datalake-access:erich
     ccx-srep-data-access:inecas,jzeleny,kgordeev,mbacovsk,sochotni
     insights-admins:bfahr
     eda:eda-admin


### PR DESCRIPTION
* Added special groups for Insights to give dashboard developers access to the insights database, and rover groups for end-users to consume the dashboards
* Added telemetry-automated service account, with read-only access to `telemetry`, `ccx`, and `ccx_sensitive` Trino schemas