### PR TITLE
Fix Trino ACL configuration

### DIFF
--- a/kfdefs/base/trino/trino-config-secret.yaml
+++ b/kfdefs/base/trino/trino-config-secret.yaml
@@ -53,10 +53,9 @@ stringData:
     telemetry:ridubey,skamired,jenndavi,weaton,xinfli,cchase,egranger,cblum,telemetry-automated
     cost-management:chambrid,kholdawa,aberglun,mskarbek,hproctor,aaiken
     rhods:jdemoss,egranger,cchase,gmoutier
-    assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
+    assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil,telemetry-automated # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
     ccx-datalake-access:erich,aravindh,akoshlak,wabuahma,kfyfe,kmamgain,shzhou
     ccx-sensitive-datalake-access:erich,kfyfe,akoshlak
-    assisted-lakers:odepaz,lgamliel,rfreiman,milevy,eerez,rpiccoli,agentil,telemetry-automated # Note that, as agreed upon by the CCX team, Rom Freiman and Liat Gamliel are responsible for maintaining membership of this group.
     ccx-datalake-access:erich,aravindh,akoshlak,wabuahma
     ccx-sensitive-datalake-access:erich
     ccx-srep-data-access:inecas,jzeleny,kgordeev,mbacovsk,sochotni


### PR DESCRIPTION
* Removed a duplicate line in `group-mapping.properties`
* Added `telemetry-automated` service account to the correct group