### PR TITLE
Automatically rollout the trino-coordinator on config change

### DIFF
--- a/kfdefs/base/trino/kustomization.yaml
+++ b/kfdefs/base/trino/kustomization.yaml
@@ -19,6 +19,9 @@ resources:
 generators:
 - ./secret-generator.yaml
 
+transformers:
+  - trino-coordinator-hash-annotator.yaml
+
 images:
   - name: quay.io/opendatahub/trino:361
     newName: quay.io/opendatahub/trino

--- a/kfdefs/base/trino/trino-coordinator-hash-annotator.yaml
+++ b/kfdefs/base/trino/trino-coordinator-hash-annotator.yaml
@@ -1,0 +1,13 @@
+apiVersion: pcjun97/v1
+kind: HashAnnotator
+metadata:
+  name: trino-coordinator-hash-annotator
+targets:
+  - kind: Deployment
+    name: trino-coordinator
+resources:
+  - kind: Secret
+    name: trino-config
+fieldSpecs:
+  - path: spec/template/metadata/annotations
+    create: true


### PR DESCRIPTION
This change implements use of the
https://github.com/pcjun97/kustomize-hash-annotator kustomize plugins to
automatically annotate the trino-coordinator deployment with the hash of
the trino-config secret. This way, any time we change the trino-config,
the coordinator will automatically perform a new rollout without manual
intervention.