### PR TITLE
Update permissions for trino catalogs

### DIFF
--- a/kfdefs/base/trino/trino-config-secret.yaml
+++ b/kfdefs/base/trino/trino-config-secret.yaml
@@ -83,15 +83,11 @@ stringData:
           "allow": "all"
         },
         {
-        "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|usir|openshift-analytics|telemetry|cost-management|assisted-lakers|ccx-datalake-access|ccx-sensitive-datalake-access|ccx-srep-data-access|insights-admins|insights-digests-viewers|insights-warehouse-viewers|eda|rhods-pxe",
-          "allow": "read-only"
-        },
-        {
           "user": "ccx-admin",
           "allow": "all"
         },
         {
-          "allow": "none"
+          "allow": "read-only"
         }
       ],
       "schemas": [


### PR DESCRIPTION
This change simplifies our permissions around Trino catalogs. It makes
    it so that any logged in user has read-only access to the list of
    catalogs.
    
    This will not wholesale grant all users access to all data as we have
    restrictions further down the file on schema and table level access.