### PR TITLE
Update the Trino ACLs every 30 seconds

### DIFF
--- a/kfdefs/base/trino/trino-config-secret.yaml
+++ b/kfdefs/base/trino/trino-config-secret.yaml
@@ -75,6 +75,7 @@ stringData:
   access-control.properties: |-
     access-control.name=file
     security.config-file=/etc/trino/rules.json
+    security.refresh-period=30s
   rules.json: |-
     {
       "catalogs": [


### PR DESCRIPTION
With this we won't have to restart the trino coordinator anymore to
apply ACL changes.