### PR TITLE
Add a superset user to Trino

### DIFF
--- a/kfdefs/base/trino/trino-config-secret.yaml
+++ b/kfdefs/base/trino/trino-config-secret.yaml
@@ -46,6 +46,7 @@ stringData:
     superset-ccx:$2y$10$7iX1DTBkI0JHO22xibaiOOLLf9j0U/.p9u9AtetlXCx2ChKMawFSO
     superset-ccx-sensitive:$2y$10$w07WSZE3eGLqnFHI/IixNuvYuDQfl.iJN2bBI1ddNPlGLPpSuuQfq
     superset-ray-parquet-compaction:$2y$10$.9ek5KJbhlkw633GrseViuy.amPBOaFpwHJvwtLPpEUprWFLTBczK
+    superset:$2y$10$IXQTPIRoeQ7NMgC9cl7jeelRfMA6Yg1lFlkAAibdA9Ty2HO2KY2h6
   group-provider.properties: |-
     group-provider.name=file
     file.group-file=/etc/trino/group-mapping.properties
@@ -80,6 +81,12 @@ stringData:
     security.refresh-period=30s
   rules.json: |-
     {
+      "impersonation": [
+        {
+          "original_user": "superset",
+          "new_user": ".*"
+        }
+      ],
       "catalogs": [
         {
           "group": "data-hub-admins",


### PR DESCRIPTION
We will work towards updating Superset to use this service account for
connecting to Trino for all datasets. This service account deliberately
does not have any explicit data set permissions defined. We will instead
rely on user impersonation to control what datasets can be accessed.

We will not be able to fully implement user impersonation on all
Superset databases yet until we have LDAP group support in Trino, but
for some datasets we're ready today.