### PR TITLE
Fix authorization to telemetry grafana

### DIFF
--- a/telemetry-grafana/base/grafana-deploymentconfig.yaml
+++ b/telemetry-grafana/base/grafana-deploymentconfig.yaml
@@ -113,6 +113,7 @@ spec:
             - '--openshift-service-account=grafana'
             - '--upstream=http://localhost:3001'
             - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "grafana"}}'
+            - '--openshift-sar={"resource": "route", "resourceName": "grafana", "verb": "get"}'
             - '--tls-cert=/etc/tls/private/tls.crt'
             - '--tls-key=/etc/tls/private/tls.key'
             - '-cookie-secret-file=/etc/proxy/secrets/session_secret'


### PR DESCRIPTION
It turns out that for oauth-based authentication providers, this
--openshift-sar argument is needed to properly limit who can access a
given resource. Without this, anyone who can successfully log into the
openshift cluster can access grafana.