### PR TITLE
Actually fix the telemetry grafana access

### DIFF
--- a/telemetry-grafana/base/grafana-deploymentconfig.yaml
+++ b/telemetry-grafana/base/grafana-deploymentconfig.yaml
@@ -113,6 +113,7 @@ spec:
             - '--openshift-service-account=grafana'
             - '--upstream=http://localhost:3001'
             - '--openshift-delegate-urls={"/": {"resource": "route", "verb": "get", "name": "grafana"}}'
+            - '--openshift-sar={"resource": "services", "resourceName": "grafana", "verb": "get"}'
             - '--tls-cert=/etc/tls/private/tls.crt'
             - '--tls-key=/etc/tls/private/tls.key'
             - '-cookie-secret-file=/etc/proxy/secrets/session_secret'


### PR DESCRIPTION
It seems that using "route" doesn't work nicely in the openshift subject
access reivew. I've confirmed that "services" actually does what I want
it to.