### PR TITLE
Update Makefile to work for generic LDAP groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,16 @@ PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+getmembers = $(shell \
+	ldapsearch -x -H ldap://ldap.corp.redhat.com -LLL -b 'ou=adhoc,ou=managedGroups,dc=redhat,dc=com' 'cn=$(1)' \
+	|grep uniqueMember \
+	|sed "s/.*uid=\([^,]*\),.*/\1/g" \
+	|sort \
+	|paste -sd "," \
+	|awk '{print "$(1):"$$1}')
+
+updatemembers = $(shell sed -i "s/^$(1):.*$$/$(call getmembers,$(1))/" kfdefs/base/trino/trino-group-mapping.properties)
+
 CCX_SENSITIVE := $(shell \
 	ldapsearch -x -H ldap://ldap.corp.redhat.com -LLL -b 'ou=adhoc,ou=managedGroups,dc=redhat,dc=com' 'cn=ccx-sensitive-datalake-access' \
 	|grep uniqueMember \
@@ -25,7 +35,8 @@ CCX_SREP := $(shell \
 	|paste -sd "," \
 	|awk '{print "ccx-srep-data-access:"$$1}')
 
-update-ccx-groups: ## Update ccx trino access groups from LDAP
+update-trino-groups: ## Update trino access groups from LDAP
+	$(call updatemembers,data-hub-openshift-admins)
 	@sed -i "s/^ccx-sensitive-datalake-access:.*$$/$(CCX_SENSITIVE)/" kfdefs/base/trino/trino-group-mapping.properties
 	@sed -i "s/^ccx-datalake-access:.*$$/$(CCX)/" kfdefs/base/trino/trino-group-mapping.properties
 	@sed -i "s/^ccx-srep-data-access:.*$$/$(CCX_SREP)/" kfdefs/base/trino/trino-group-mapping.properties

--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 A repo housing deployment artifacts for components of the Internal
 Data Hub that are not managed by the ODH operator.
 
+## Updating Trino Group Membership
+
+We manage [Trino group membership](kfdefs/base/trino/trino-group-mapping.properties) by
+manually replicating LDAP group membership into the group membership file. To automate this
+process, we have a [Makefile](Makefile) that, when run, will sync all rover groups that
+we care about into the properties file.
+
+To update group membership, simply run the following command from the root of
+this repository:
+
+```bash
+make update-trino-groups
+```
+
 ## Development Instructions
 
 ### Running Pre-Commit Tests

--- a/kfdefs/base/trino/trino-group-mapping.properties
+++ b/kfdefs/base/trino/trino-group-mapping.properties
@@ -1,4 +1,5 @@
 data-hub-admins:aasthana,acorvin,gfrasca,jvaikath,lferrnan,mshah,rmartine,trino-admin
+data-hub-openshift-admins:aasthana,acorvin,ddalvi,gfrasca,hukhan,hveeradh,jvaikath,lferrnan,rmartine,shgriffi
 ccx:afalossi,inecas,kgordeev,mbacovsk,mklika,ometelka,sochotni,tdosek,tsedlace,jholecek,erjones,mleonard,ireyes
 grokket:jmarlow,lmasse,mguan
 product-marketing:rking,tibrahim


### PR DESCRIPTION
This is the first in a series of pull requests that will update our group membership properties file to pull from rover groups. 