### PR TITLE
Added syncing of Trino access for ccx-dev group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ CCX_SREP := $(shell \
 
 update-trino-groups: ## Update trino access groups from LDAP
 	$(call updatemembers,data-hub-openshift-admins)
+	$(call updatemembers,ccx-dev)
 	@sed -i "s/^ccx-sensitive-datalake-access:.*$$/$(CCX_SENSITIVE)/" kfdefs/base/trino/trino-group-mapping.properties
 	@sed -i "s/^ccx-datalake-access:.*$$/$(CCX)/" kfdefs/base/trino/trino-group-mapping.properties
 	@sed -i "s/^ccx-srep-data-access:.*$$/$(CCX_SREP)/" kfdefs/base/trino/trino-group-mapping.properties

--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -28,7 +28,7 @@
         "owner": true
     },
     {
-        "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|telemetry|rhods-pxe",
+        "group": "ccx-dev|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|telemetry|rhods-pxe",
         "schema": "telemetry",
         "owner": true
     },
@@ -48,7 +48,7 @@
         "owner": true
     },
     {
-        "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|usir|telemetry|cost-management",
+        "group": "ccx-dev|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|usir|telemetry|cost-management",
         "schema": "jdbc",
         "owner": true
     },
@@ -96,12 +96,12 @@
         "privileges": ["SELECT"]
     },
     {
-        "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|telemetry|rhods-pxe",
+        "group": "ccx-dev|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|telemetry|rhods-pxe",
         "schema": "telemetry",
         "privileges": ["SELECT"]
     },
     {
-        "group": "ccx|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|telemetry|rhods-pxe",
+        "group": "ccx-dev|grokket|product-marketing|openshift|openshift-community-enablement|acm-observability|openshift-qe|ansible-engineering|openshift-analytics|telemetry|rhods-pxe",
         "schema": "telemetry_curated",
         "privileges": ["SELECT"]
     },
@@ -120,12 +120,12 @@
         "privileges": ["SELECT"]
     },
     {
-        "group": "ccx|assisted-lakers|ccx-datalake-access",
+        "group": "ccx-dev|assisted-lakers|ccx-datalake-access",
         "schema": "ccx",
         "privileges": ["SELECT"]
     },
     {
-        "group": "ccx|assisted-lakers|ccx-sensitive-datalake-access",
+        "group": "ccx-dev|assisted-lakers|ccx-sensitive-datalake-access",
         "schema": "ccx_sensitive",
         "privileges": ["SELECT"]
     },

--- a/kfdefs/base/trino/trino-group-mapping.properties
+++ b/kfdefs/base/trino/trino-group-mapping.properties
@@ -1,6 +1,6 @@
 data-hub-admins:aasthana,acorvin,gfrasca,jvaikath,lferrnan,mshah,rmartine,trino-admin
-data-hub-openshift-admins:aasthana,acorvin,ddalvi,gfrasca,hukhan,hveeradh,jvaikath,lferrnan,rmartine,shgriffi
-ccx:afalossi,inecas,kgordeev,mbacovsk,mklika,ometelka,sochotni,tdosek,tsedlace,jholecek,erjones,mleonard,ireyes
+data-hub-openshift-admins:aasthana,acorvin,croberts,ddalvi,gfrasca,jvaikath,rmartine
+ccx-dev:afalossi,akoshlak,avoznese,dbily,dmisharo,dpensier,gkaratae,inecas,ireyes,jdiazsua,jfrieser,jfula,jholecek,jipapous,jkrocil,jsegural,jzeleny,kgordeev,mbacovsk,mklika,mslabejo,mzibrick,ometelka,pcamara,psi-ccx-sa,ptisnovs,rhrmo,rluders,sochotni,tnovotny,tremes,tsedlace,wabuahma
 grokket:jmarlow,lmasse,mguan
 product-marketing:rking,tibrahim
 openshift-community-enablement:jfiala


### PR DESCRIPTION
- Trino group `ccx` was renamed to `ccx-dev` to match the rover group. Is the group referenced somewhere else?
- Syncing of rover group "ccx-dev" was added to the Makefile.
- groups were synced - WARN: members of `data-hub-openshift-admins` were updated as a side effect
