### PR TITLE
Allow the trino-admin user to impersonate any user in trino

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -1,7 +1,7 @@
 {
     "impersonation": [
     {
-        "original_user": "superset",
+        "original_user": "superset|trino-admin",
         "new_user": ".*"
     }
     ],


### PR DESCRIPTION
In order for the LDAP group provider in Trino to work, Superset needs to
connect to Trino using a valid user that exists in LDAP. We're therefore
switch to using the trino-admin user for this connection instead of the
currently used superset user. The trino-admin user then needs
permissions to impersonate any logged in user.