### PR TITLE
Grant impersonation permissions to new superset user

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -1,7 +1,7 @@
 {
     "impersonation": [
     {
-        "original_user": "superset|trino-admin",
+        "original_user": "superset|trino-admin|data-hub-superset-trino",
         "new_user": ".*"
     }
     ],


### PR DESCRIPTION
We need to configure Superset to use a valid LDAP user for connecting to
Trino. To prevent unauthorized data access, this user should have no
permissions in trino other than user impersonation, so we can't use the
existing trino-admin LDAP user. This change grants impersonation
permissions to the new data-hub-superset-trino user that we got created
for this purpose.