### PR TITLE
Update the trino admin password for obslytics

### DIFF
--- a/obslytics/overlays/dev/secrets/obslytics-secret.enc.yaml
+++ b/obslytics/overlays/dev/secrets/obslytics-secret.enc.yaml
@@ -18,12 +18,11 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:55:00Z"
-    mac: ENC[AES256_GCM,data:8LPrA8ODPu+KxSzCBltG/NdPvLExXASjm6Zbhx1dWK8/CcX4kGu/GnTtZSh6nKlqo2/M2cVCFUuHWc3sMDofmY8yxOzSQXypS0X+j63QiTPfcOT93eUreYkPJEL1CO3AEmoRFfCsYTVra6PA0ISV23WDXRx1tN5qi1UXSJ6v4Os=,iv:s3oqiSM+6u8H6h/NKrUl4kN4+pFbKtNOROs40PX9N/Y=,tag:2xzRycBlRpmcGOVT6Vo0ww==,type:str]
+    lastmodified: '2022-08-24T15:40:32Z'
+    mac: ENC[AES256_GCM,data:E1g+eeMNxtFZ7a6F2grznXbU6+kNXgMMVcJtCGlWLSfrDwPWwMVAdfbyfb65hSG1icR2TVxZiro5a0sZsuSQmrQlnxmuCsRFIiclUjGksDvHHJpJ+hmclHnNGrrgmQC1TK9BLSrZlM3GMdXRzUnqWoFUjELiwuLzn1HG2xUAQZ4=,iv:o9OaBT67oVldofnPCIGWlnxDS385TJWLfAVuoOjhdEk=,tag:Zl/H7Mqu0MxspR1e/D9jUw==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:54:59Z"
-          enc: |
+    -   created_at: '2021-11-17T15:54:59Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf9G3gjk6588aAMn1wA5Z26b2JMVp0U0gFcROzwEFQ7tX0C
@@ -36,7 +35,7 @@ sops:
             g5jAF8TMtZYMsf20oZcGO9Mi06f9MqzeMrBlI1ZTnQ==
             =jiP7
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1
 ---
@@ -55,12 +54,11 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:55:00Z"
-    mac: ENC[AES256_GCM,data:8LPrA8ODPu+KxSzCBltG/NdPvLExXASjm6Zbhx1dWK8/CcX4kGu/GnTtZSh6nKlqo2/M2cVCFUuHWc3sMDofmY8yxOzSQXypS0X+j63QiTPfcOT93eUreYkPJEL1CO3AEmoRFfCsYTVra6PA0ISV23WDXRx1tN5qi1UXSJ6v4Os=,iv:s3oqiSM+6u8H6h/NKrUl4kN4+pFbKtNOROs40PX9N/Y=,tag:2xzRycBlRpmcGOVT6Vo0ww==,type:str]
+    lastmodified: '2022-08-24T15:40:32Z'
+    mac: ENC[AES256_GCM,data:E1g+eeMNxtFZ7a6F2grznXbU6+kNXgMMVcJtCGlWLSfrDwPWwMVAdfbyfb65hSG1icR2TVxZiro5a0sZsuSQmrQlnxmuCsRFIiclUjGksDvHHJpJ+hmclHnNGrrgmQC1TK9BLSrZlM3GMdXRzUnqWoFUjELiwuLzn1HG2xUAQZ4=,iv:o9OaBT67oVldofnPCIGWlnxDS385TJWLfAVuoOjhdEk=,tag:Zl/H7Mqu0MxspR1e/D9jUw==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:54:59Z"
-          enc: |
+    -   created_at: '2021-11-17T15:54:59Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf9G3gjk6588aAMn1wA5Z26b2JMVp0U0gFcROzwEFQ7tX0C
@@ -73,7 +71,7 @@ sops:
             g5jAF8TMtZYMsf20oZcGO9Mi06f9MqzeMrBlI1ZTnQ==
             =jiP7
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1
 ---
@@ -83,19 +81,18 @@ metadata:
     name: trino-admin-credentials
 stringData:
     TRINO_USER: ENC[AES256_GCM,data:OVCpdDxiV3IgmA0=,iv:9iMrUQEZXpU2doz2OYH5GmAxT24naEHrueZ2t0uC5vg=,tag:3VdWKT6vZDVI5tuHLG6rAw==,type:str]
-    TRINO_PASSWORD: ENC[AES256_GCM,data:yQm8Sx7mfJTzJECvR3T8IA==,iv:lPuVH+ZRcy0dyT5qd1X6+1VhkMnbtgw0m0MyKYk9uTc=,tag:GUtjr9g8TUJRVLXIOF7wzw==,type:str]
+    TRINO_PASSWORD: ENC[AES256_GCM,data:UC9NNhG2CKzopBxiuEo17ITjJ0baTXOjqxTMglq2Wis=,iv:ayIosoguo7K39yeSvY1j/4bgPAE1qLHQhN1E0SB7+GU=,tag:Aul0tBbGwREou7IoW6z8Aw==,type:str]
     TRINO_HOST: ENC[AES256_GCM,data:EgNNHB3gMWecqNkAsrJKAbUDdC+pPbak,iv:U9aDadBeU34SQQRp2zqeHuF2VKlAbF7MCpmdePTJN48=,tag:fcnOFgQJv1mj4vv4y++dRQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:55:00Z"
-    mac: ENC[AES256_GCM,data:8LPrA8ODPu+KxSzCBltG/NdPvLExXASjm6Zbhx1dWK8/CcX4kGu/GnTtZSh6nKlqo2/M2cVCFUuHWc3sMDofmY8yxOzSQXypS0X+j63QiTPfcOT93eUreYkPJEL1CO3AEmoRFfCsYTVra6PA0ISV23WDXRx1tN5qi1UXSJ6v4Os=,iv:s3oqiSM+6u8H6h/NKrUl4kN4+pFbKtNOROs40PX9N/Y=,tag:2xzRycBlRpmcGOVT6Vo0ww==,type:str]
+    lastmodified: '2022-08-24T15:40:32Z'
+    mac: ENC[AES256_GCM,data:E1g+eeMNxtFZ7a6F2grznXbU6+kNXgMMVcJtCGlWLSfrDwPWwMVAdfbyfb65hSG1icR2TVxZiro5a0sZsuSQmrQlnxmuCsRFIiclUjGksDvHHJpJ+hmclHnNGrrgmQC1TK9BLSrZlM3GMdXRzUnqWoFUjELiwuLzn1HG2xUAQZ4=,iv:o9OaBT67oVldofnPCIGWlnxDS385TJWLfAVuoOjhdEk=,tag:Zl/H7Mqu0MxspR1e/D9jUw==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:54:59Z"
-          enc: |
+    -   created_at: '2021-11-17T15:54:59Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf9G3gjk6588aAMn1wA5Z26b2JMVp0U0gFcROzwEFQ7tX0C
@@ -108,6 +105,6 @@ sops:
             g5jAF8TMtZYMsf20oZcGO9Mi06f9MqzeMrBlI1ZTnQ==
             =jiP7
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1

--- a/obslytics/overlays/ocp4-migration/secrets/obslytics-secret.enc.yaml
+++ b/obslytics/overlays/ocp4-migration/secrets/obslytics-secret.enc.yaml
@@ -18,8 +18,8 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-11-24T23:14:07Z'
-    mac: ENC[AES256_GCM,data:KI/jFp+y0BZ0CFxDbhgx+LogM6juj4INmc21hUnT5hhQMQko3l5fusv54DN8qGPg69kkLLn521KjT8OhBVpnm52DNswloM3OF0dqSQ6he0BhVJ2R3I4ZXl03dy1VqalZhq9UdUCKyL0OcshAetwWMs7XPMbdXCqt8847CPK9U2g=,iv:oBBzNKVD5LebPTPqbdUrPhMXz2FIjv+uY+wA11cbga8=,tag:k0lRBNg3N8kt2jlTr3dyZQ==,type:str]
+    lastmodified: '2022-08-24T15:40:54Z'
+    mac: ENC[AES256_GCM,data:a8pDDCWWcHNyDlDlW1FxnAXhyxzL+B2WtzRIcqnZEkEu3NW+Aq+uh7X/y6lZ5lV8KdVPa9oj3yvvAX0k7eQXLdWvORQYhPe/tzai72pM6e4VX11HpCFFn58jQMeCTG0WQV4maZ4ucOsLPYGgz7pe2v7zbZNhi7CfMDR3KdoLEMc=,iv:4Kw4g5BO8O2E5688NCslOlYYcszQCty14vGHdpTr9uk=,tag:9kBo0OTiPUYRRRkx3INgvw==,type:str]
     pgp:
     -   created_at: '2021-11-17T15:55:50Z'
         enc: |
@@ -54,8 +54,8 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-11-24T23:14:07Z'
-    mac: ENC[AES256_GCM,data:KI/jFp+y0BZ0CFxDbhgx+LogM6juj4INmc21hUnT5hhQMQko3l5fusv54DN8qGPg69kkLLn521KjT8OhBVpnm52DNswloM3OF0dqSQ6he0BhVJ2R3I4ZXl03dy1VqalZhq9UdUCKyL0OcshAetwWMs7XPMbdXCqt8847CPK9U2g=,iv:oBBzNKVD5LebPTPqbdUrPhMXz2FIjv+uY+wA11cbga8=,tag:k0lRBNg3N8kt2jlTr3dyZQ==,type:str]
+    lastmodified: '2022-08-24T15:40:54Z'
+    mac: ENC[AES256_GCM,data:a8pDDCWWcHNyDlDlW1FxnAXhyxzL+B2WtzRIcqnZEkEu3NW+Aq+uh7X/y6lZ5lV8KdVPa9oj3yvvAX0k7eQXLdWvORQYhPe/tzai72pM6e4VX11HpCFFn58jQMeCTG0WQV4maZ4ucOsLPYGgz7pe2v7zbZNhi7CfMDR3KdoLEMc=,iv:4Kw4g5BO8O2E5688NCslOlYYcszQCty14vGHdpTr9uk=,tag:9kBo0OTiPUYRRRkx3INgvw==,type:str]
     pgp:
     -   created_at: '2021-11-17T15:55:50Z'
         enc: |
@@ -81,15 +81,15 @@ metadata:
     name: trino-admin-credentials
 stringData:
     TRINO_USER: ENC[AES256_GCM,data:lVMRN2f6OEDEuu4=,iv:hndQ6MuOxdDbZstzMbfL9PR+oTgeWxpzxiQIhsPvMCI=,tag:K61s1y8E2lbKgSRBFk7SdQ==,type:str]
-    TRINO_PASSWORD: ENC[AES256_GCM,data:bx0pl5Nn4X3oMzcII7NGeA==,iv:DQyVBqCrYhRvXYPr/W6PTjYgukRe24LXq7JYy7UvEZQ=,tag:a8OweRor2bScD3023B7tqA==,type:str]
+    TRINO_PASSWORD: ENC[AES256_GCM,data:cARETlXugUfQPaheOt296N/l0wWklCfWvPrdZIbtYeo=,iv:BFGvLFKBRzU/NOlTjFwe870PUB/fs0Jd082V0P3F59o=,tag:BD+xnfi7xrNh36TvOgL+1w==,type:str]
     TRINO_HOST: ENC[AES256_GCM,data:q7ApnK0DgrbBLybuFHrPs7TwLDOdYWiZ,iv:AyzbDVata1ANIduzSffefe3IryxXx0ZSk5gs8Be+gbI=,tag:AW/w6UeFapS8x9HknBIWHA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-11-24T23:14:07Z'
-    mac: ENC[AES256_GCM,data:KI/jFp+y0BZ0CFxDbhgx+LogM6juj4INmc21hUnT5hhQMQko3l5fusv54DN8qGPg69kkLLn521KjT8OhBVpnm52DNswloM3OF0dqSQ6he0BhVJ2R3I4ZXl03dy1VqalZhq9UdUCKyL0OcshAetwWMs7XPMbdXCqt8847CPK9U2g=,iv:oBBzNKVD5LebPTPqbdUrPhMXz2FIjv+uY+wA11cbga8=,tag:k0lRBNg3N8kt2jlTr3dyZQ==,type:str]
+    lastmodified: '2022-08-24T15:40:54Z'
+    mac: ENC[AES256_GCM,data:a8pDDCWWcHNyDlDlW1FxnAXhyxzL+B2WtzRIcqnZEkEu3NW+Aq+uh7X/y6lZ5lV8KdVPa9oj3yvvAX0k7eQXLdWvORQYhPe/tzai72pM6e4VX11HpCFFn58jQMeCTG0WQV4maZ4ucOsLPYGgz7pe2v7zbZNhi7CfMDR3KdoLEMc=,iv:4Kw4g5BO8O2E5688NCslOlYYcszQCty14vGHdpTr9uk=,tag:9kBo0OTiPUYRRRkx3INgvw==,type:str]
     pgp:
     -   created_at: '2021-11-17T15:55:50Z'
         enc: |

--- a/obslytics/overlays/prod/secrets/obslytics-secret.enc.yaml
+++ b/obslytics/overlays/prod/secrets/obslytics-secret.enc.yaml
@@ -18,12 +18,11 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:56:18Z"
-    mac: ENC[AES256_GCM,data:V6XD+FJTnhwWtOOMxU4JyzJRS7VCAWUY3GNkWwUxFfoEZ7pzLgVLlrNpNyYKwIXhlmbgHy55ZxCtl6jYC1nJ7geQvC6bWy3gxTDGtFvZ0UYBM3nS65uoaGaHOdS4OwhosHfeUuxCibtOQWHyCgmmTIT3TrUr7Pm0kdITx5F/mpY=,iv:QkgExntBibWxzS9Tgb+HGGRCTCt9HPG26wI/M4z4ITA=,tag:hBbPmfdkvgDpuzEeqXfj0A==,type:str]
+    lastmodified: '2022-08-24T15:40:44Z'
+    mac: ENC[AES256_GCM,data:OSXJhWC2lCnyMlJPv+8TZQXvSk1AQUxkLQg8JSCNulehC/yYNQOMTLE3//4padB4YbMk3gvzdHQnk9OpSX2UPcHpLYjRh/QZ5k0GHeSvnvHk9+cECGiifsZ8ITjrlbHjd4q7NaSi9xHeh+MGFvfZ7ojskkLj9esSaCdqEOSiTbU=,iv:S+n4MCSoSjak11C13XZrHlQhOvHvsZOtUU1TuDkuc+Q=,tag:rO+Tn/+8870S3lhLgTn1aA==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:56:18Z"
-          enc: |
+    -   created_at: '2021-11-17T15:56:18Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf/e65w8rvQb8HfqxTAgdVogZ/S+6o3P6fpKsbCF86zV8uS
@@ -36,7 +35,7 @@ sops:
             O0MRuK/KZuuUnh/V93CG3toWhou/exbHGygFsQUjCg==
             =xdeX
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1
 ---
@@ -55,12 +54,11 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:56:18Z"
-    mac: ENC[AES256_GCM,data:V6XD+FJTnhwWtOOMxU4JyzJRS7VCAWUY3GNkWwUxFfoEZ7pzLgVLlrNpNyYKwIXhlmbgHy55ZxCtl6jYC1nJ7geQvC6bWy3gxTDGtFvZ0UYBM3nS65uoaGaHOdS4OwhosHfeUuxCibtOQWHyCgmmTIT3TrUr7Pm0kdITx5F/mpY=,iv:QkgExntBibWxzS9Tgb+HGGRCTCt9HPG26wI/M4z4ITA=,tag:hBbPmfdkvgDpuzEeqXfj0A==,type:str]
+    lastmodified: '2022-08-24T15:40:44Z'
+    mac: ENC[AES256_GCM,data:OSXJhWC2lCnyMlJPv+8TZQXvSk1AQUxkLQg8JSCNulehC/yYNQOMTLE3//4padB4YbMk3gvzdHQnk9OpSX2UPcHpLYjRh/QZ5k0GHeSvnvHk9+cECGiifsZ8ITjrlbHjd4q7NaSi9xHeh+MGFvfZ7ojskkLj9esSaCdqEOSiTbU=,iv:S+n4MCSoSjak11C13XZrHlQhOvHvsZOtUU1TuDkuc+Q=,tag:rO+Tn/+8870S3lhLgTn1aA==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:56:18Z"
-          enc: |
+    -   created_at: '2021-11-17T15:56:18Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf/e65w8rvQb8HfqxTAgdVogZ/S+6o3P6fpKsbCF86zV8uS
@@ -73,7 +71,7 @@ sops:
             O0MRuK/KZuuUnh/V93CG3toWhou/exbHGygFsQUjCg==
             =xdeX
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1
 ---
@@ -83,19 +81,18 @@ metadata:
     name: trino-admin-credentials
 stringData:
     TRINO_USER: ENC[AES256_GCM,data:dY+GH4dyPqYHBuI=,iv:3pZJLkVI9Uyk5Dd2niP0fTIGyiRCHIePh/B2g2osI4Q=,tag:KHeZm7MwWED0h1RUpKkzeQ==,type:str]
-    TRINO_PASSWORD: ENC[AES256_GCM,data:wU4KKlxJ7Hr+iI91DFKvVw==,iv:IIjonJ1fmCZNVFzeRWEUxadnN+dB1kRn6R5uiUSmCmA=,tag:z/uYjRHL9VF7E6z4ZWV/iQ==,type:str]
+    TRINO_PASSWORD: ENC[AES256_GCM,data:5/4BCFswenFk//7dHc53CrSg9ZEzQ/LF2gw8ihDzfFM=,iv:2Tn99VoGBxtyWUQjAYgOjOoU+KfN8nFOM6JskWbge4Y=,tag:oLlkdLtd3iUt4QNsWFz1XQ==,type:str]
     TRINO_HOST: ENC[AES256_GCM,data:IWsNKmqCdXF4tYz9bA7hWf4yA0TRfwpq,iv:sCyN9nygNONYn6Y9UfvYoF+TY9nXFcoU4PklUxvPCgE=,tag:hpoh92rPqa6m2MMdbUgZOQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:56:18Z"
-    mac: ENC[AES256_GCM,data:V6XD+FJTnhwWtOOMxU4JyzJRS7VCAWUY3GNkWwUxFfoEZ7pzLgVLlrNpNyYKwIXhlmbgHy55ZxCtl6jYC1nJ7geQvC6bWy3gxTDGtFvZ0UYBM3nS65uoaGaHOdS4OwhosHfeUuxCibtOQWHyCgmmTIT3TrUr7Pm0kdITx5F/mpY=,iv:QkgExntBibWxzS9Tgb+HGGRCTCt9HPG26wI/M4z4ITA=,tag:hBbPmfdkvgDpuzEeqXfj0A==,type:str]
+    lastmodified: '2022-08-24T15:40:44Z'
+    mac: ENC[AES256_GCM,data:OSXJhWC2lCnyMlJPv+8TZQXvSk1AQUxkLQg8JSCNulehC/yYNQOMTLE3//4padB4YbMk3gvzdHQnk9OpSX2UPcHpLYjRh/QZ5k0GHeSvnvHk9+cECGiifsZ8ITjrlbHjd4q7NaSi9xHeh+MGFvfZ7ojskkLj9esSaCdqEOSiTbU=,iv:S+n4MCSoSjak11C13XZrHlQhOvHvsZOtUU1TuDkuc+Q=,tag:rO+Tn/+8870S3lhLgTn1aA==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:56:18Z"
-          enc: |
+    -   created_at: '2021-11-17T15:56:18Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf/e65w8rvQb8HfqxTAgdVogZ/S+6o3P6fpKsbCF86zV8uS
@@ -108,6 +105,6 @@ sops:
             O0MRuK/KZuuUnh/V93CG3toWhou/exbHGygFsQUjCg==
             =xdeX
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1

--- a/obslytics/overlays/stage/secrets/obslytics-secret.enc.yaml
+++ b/obslytics/overlays/stage/secrets/obslytics-secret.enc.yaml
@@ -18,12 +18,11 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:56:45Z"
-    mac: ENC[AES256_GCM,data:VqzsadIWt34F7FhPKiad7rMW1Bjax9olFEiue7qHvfMOeLl8JZ2nB13hhw+KBkiYwQB6zC+yscbYOTtHW8vrbjzvjDymDUAGawZaOyJHGzAIiUMTPGJ3HdyhnGG1QY4F8z7dByxNqdy5GTNUohqz/Pasviz1dUlFQUeJn3aAhNQ=,iv:GS4mJmp4MatYmKfCB3NbD9uJIqLxdAJWY2o3vrIiDPs=,tag:KzmoaMzLDUdxg6658kZUKg==,type:str]
+    lastmodified: '2022-08-24T15:41:08Z'
+    mac: ENC[AES256_GCM,data:027dLQWHxFt136rj7PUsRZVyfttz+nB1pVNw3s0t4nGJCS34eaHnwfjM8VwIRNDYLhKY1HfwAQLFzv5uCFMagzyDLheGKYw54RaWJoThjabNtOLkqQlKDrgJ8VAQz0EoI3LVt75++jfAJDJ7jjNUhxACCSowGDnKj+46w3YVIT0=,iv:PBuw/jNIrDuGOBmSB4zuaNvqzQS8lxejCjzPBBpuids=,tag:AjRUohtQp96qt5cXofjDkw==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:56:44Z"
-          enc: |
+    -   created_at: '2021-11-17T15:56:44Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf9GYHshk5M/DvsAwwIPjh4yPIYz/20+acGil7ZkT0eGzu/
@@ -36,7 +35,7 @@ sops:
             JmXUDoESzHM78ZpmnAOOjRxWXojT8WQwE/ZdLpAHUw==
             =8HR8
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1
 ---
@@ -55,12 +54,11 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:56:45Z"
-    mac: ENC[AES256_GCM,data:VqzsadIWt34F7FhPKiad7rMW1Bjax9olFEiue7qHvfMOeLl8JZ2nB13hhw+KBkiYwQB6zC+yscbYOTtHW8vrbjzvjDymDUAGawZaOyJHGzAIiUMTPGJ3HdyhnGG1QY4F8z7dByxNqdy5GTNUohqz/Pasviz1dUlFQUeJn3aAhNQ=,iv:GS4mJmp4MatYmKfCB3NbD9uJIqLxdAJWY2o3vrIiDPs=,tag:KzmoaMzLDUdxg6658kZUKg==,type:str]
+    lastmodified: '2022-08-24T15:41:08Z'
+    mac: ENC[AES256_GCM,data:027dLQWHxFt136rj7PUsRZVyfttz+nB1pVNw3s0t4nGJCS34eaHnwfjM8VwIRNDYLhKY1HfwAQLFzv5uCFMagzyDLheGKYw54RaWJoThjabNtOLkqQlKDrgJ8VAQz0EoI3LVt75++jfAJDJ7jjNUhxACCSowGDnKj+46w3YVIT0=,iv:PBuw/jNIrDuGOBmSB4zuaNvqzQS8lxejCjzPBBpuids=,tag:AjRUohtQp96qt5cXofjDkw==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:56:44Z"
-          enc: |
+    -   created_at: '2021-11-17T15:56:44Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf9GYHshk5M/DvsAwwIPjh4yPIYz/20+acGil7ZkT0eGzu/
@@ -73,7 +71,7 @@ sops:
             JmXUDoESzHM78ZpmnAOOjRxWXojT8WQwE/ZdLpAHUw==
             =8HR8
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1
 ---
@@ -83,19 +81,18 @@ metadata:
     name: trino-admin-credentials
 stringData:
     TRINO_USER: ENC[AES256_GCM,data:J3tCyS6ThPl7j/s=,iv:XS9pA8NU/CO990hTVxXa75szxjucDLx6p3+G4gB8qbg=,tag:t4rKexda3n3/r6bQsdPacA==,type:str]
-    TRINO_PASSWORD: ENC[AES256_GCM,data:F0HJVlWbVNC0UWeiOPHtZA==,iv:LB1jZlhnDyFRtuPPMBuJVyi/Jvs/tkIX1E2e8vv1gPk=,tag:khhubGXbIFVR1ca0slpQUg==,type:str]
+    TRINO_PASSWORD: ENC[AES256_GCM,data:04aypBibutHVAabHP3bwDNfPTYfSdt2YqNGDpENR0Sw=,iv:BkJwFkkGU7pYHgkzt7Yd1XnHzK5XikHpIp6pAsaR6S8=,tag:jU1jTYT0hCifWa3E3TjXgA==,type:str]
     TRINO_HOST: ENC[AES256_GCM,data:1BhSZ/Kh/Oi3IzFDEe8AALgE1TCJo/Oi,iv:LYxqPPxfDx2WusGo2p/ED5vivIVtw18+8BHjp47RMas=,tag:JmSang1p/DxNnBMaHhHmQg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    age: []
-    lastmodified: "2021-11-17T15:56:45Z"
-    mac: ENC[AES256_GCM,data:VqzsadIWt34F7FhPKiad7rMW1Bjax9olFEiue7qHvfMOeLl8JZ2nB13hhw+KBkiYwQB6zC+yscbYOTtHW8vrbjzvjDymDUAGawZaOyJHGzAIiUMTPGJ3HdyhnGG1QY4F8z7dByxNqdy5GTNUohqz/Pasviz1dUlFQUeJn3aAhNQ=,iv:GS4mJmp4MatYmKfCB3NbD9uJIqLxdAJWY2o3vrIiDPs=,tag:KzmoaMzLDUdxg6658kZUKg==,type:str]
+    lastmodified: '2022-08-24T15:41:08Z'
+    mac: ENC[AES256_GCM,data:027dLQWHxFt136rj7PUsRZVyfttz+nB1pVNw3s0t4nGJCS34eaHnwfjM8VwIRNDYLhKY1HfwAQLFzv5uCFMagzyDLheGKYw54RaWJoThjabNtOLkqQlKDrgJ8VAQz0EoI3LVt75++jfAJDJ7jjNUhxACCSowGDnKj+46w3YVIT0=,iv:PBuw/jNIrDuGOBmSB4zuaNvqzQS8lxejCjzPBBpuids=,tag:AjRUohtQp96qt5cXofjDkw==,type:str]
     pgp:
-        - created_at: "2021-11-17T15:56:44Z"
-          enc: |
+    -   created_at: '2021-11-17T15:56:44Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA/irrHa183bxAQf9GYHshk5M/DvsAwwIPjh4yPIYz/20+acGil7ZkT0eGzu/
@@ -108,6 +105,6 @@ sops:
             JmXUDoESzHM78ZpmnAOOjRxWXojT8WQwE/ZdLpAHUw==
             =8HR8
             -----END PGP MESSAGE-----
-          fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$
     version: 3.7.1


### PR DESCRIPTION
With this, our obslytics pipeline will use the trino-admin LDAP user
instead of the Trino service account. This is necessary as we're going
to remove the trino-admin Trino service account in preparation for
implementing the ldap group provider in Trino.