### PR TITLE
Allow all users to read from system.metadata tables

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -92,6 +92,11 @@
     ],
     "tables": [
     {
+        "catalog": "system",
+        "schema": "metadata",
+        "privileges": ["SELECT"]
+    },
+    {
         "group": "data-hub-openshift-admins",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP", "GRANT_SELECT"]
     },


### PR DESCRIPTION
Our users have started using comments on tables. These are stored in the
system.metadata table, so users will need read permissions there.