### PR TITLE
Add new ccx_internal schema

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -39,7 +39,7 @@
     },
     {
         "user": "ccx-admin|ccx-reporting-pipeline-trino",
-        "schema": "(ccx|ccx_sensitive|ccx_srep)",
+        "schema": "(ccx|ccx_sensitive|ccx_srep|ccx_internal)",
         "owner": true
     },
     {
@@ -130,7 +130,7 @@
     },
     {
         "user": "ccx-admin|ccx-reporting-pipeline-trino",
-        "schema": "(ccx|ccx_sensitive|ccx_srep)",
+        "schema": "(ccx|ccx_sensitive|ccx_srep|ccx_internal)",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP", "GRANT_SELECT"]
     },
     {


### PR DESCRIPTION
This adds a new ccx_internal schema.

As the schema will contain only internal data, only ccx-admin account + ccx dev users should have an access to it.