### PR TITLE
Add telemeter-auth for ccx_sensitive access

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -154,7 +154,7 @@
         "privileges": ["SELECT"]
     },
     {
-        "group": "ccx-dev|assisted-lakers|ccx-sensitive-datalake-access|ceeandpe|na-cs-tam-auto|apac-cs-tam-auto|latam-cs-tam-auto|emea-cs-tam-auto|na-ps-cs-tam-auto|emea-cs-csm-auto|emea-cs-cse-auto|emea-cs-managers|apac-cs-csm-auto|apac-cs-cse-auto|na-cs-csm-auto|na-cs-cse-auto|na-ps-cs-cse-auto|latam-cs-csm-auto|cs-csa-auto-ccx|ccx-pm",
+        "group": "ccx-dev|assisted-lakers|ccx-sensitive-datalake-access|ceeandpe|na-cs-tam-auto|apac-cs-tam-auto|latam-cs-tam-auto|emea-cs-tam-auto|na-ps-cs-tam-auto|emea-cs-csm-auto|emea-cs-cse-auto|emea-cs-managers|apac-cs-csm-auto|apac-cs-cse-auto|na-cs-csm-auto|na-cs-cse-auto|na-ps-cs-cse-auto|latam-cs-csm-auto|cs-csa-auto-ccx|ccx-pm|telemeter-auth|telemeter-auto-approval|telemeter-manual-approval",
         "schema": "ccx_sensitive",
         "privileges": ["SELECT"]
     },


### PR DESCRIPTION
No additional data is exposed to members of these groups since the underlying data is the same as telemeter. We just provide a different way to access this.