### PR TITLE
adding readonly user for ccx tables

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -139,6 +139,11 @@
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP", "GRANT_SELECT"]
     },
     {
+        "user": "ccx-reporting-pipeline-trino-readonly",
+        "schema": "(ccx|ccx_sensitive|ccx_srep|ccx_internal)",
+        "privileges": ["SELECT"]
+    },
+    {
         "user": "ccx-admin|ccx-reporting-pipeline-trino",
         "schema": "telemetry",
         "privileges": ["SELECT"]


### PR DESCRIPTION
We have a separate user for read-only access to out tables that will be used in automation to retrieve the data for reports