### PR TITLE
feat: Setting group permissions for "sos_rules_data" schema

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -254,6 +254,16 @@
         "privileges": ["SELECT"]
     },
     {
+        "group": "cide-insights",
+        "schema": "sos_rules_data",
+        "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP", "GRANT_SELECT"]
+    },
+    {
+        "group": "cide-sos-trino-access",
+        "schema": "sos_rules_data",
+        "privileges": ["SELECT"]
+    },
+    {
         "privileges": []
     }
     ]


### PR DESCRIPTION
Setting group permissions for "sos_rules_data" schema in trino-acl-rules.json