### PR TITLE
Revert enabling DASHBOARD_NATIVE_FILTERS_SET

### DIFF
--- a/kfdefs/base/superset/superset_additional_config.py
+++ b/kfdefs/base/superset/superset_additional_config.py
@@ -10,7 +10,7 @@ FEATURE_FLAGS = {
     'DASHBOARD_RBAC': True,
     'DASHBOARD_CROSS_FILTERS': True,
     'DASHBOARD_NATIVE_FILTERS': True,
-    'DASHBOARD_NATIVE_FILTERS_SET': True
+    'DASHBOARD_NATIVE_FILTERS_SET': False  # Set this to True once the flag is stable
 }
 
 AUTH_USER_REGISTRATION_ROLE = 'Datahub'


### PR DESCRIPTION
It turns out, I believe, we don't need this