### PR TITLE
Lowering privileges for the ade-trino-access group

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -271,7 +271,7 @@
     {
         "group": "ade-trino-access",
         "schema": "ceeacdata",
-        "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP", "GRANT_SELECT"]
+        "privileges": ["SELECT"]
     },
     {
         "privileges": []


### PR DESCRIPTION
As the creator of this group, I approve the lowering of these permissions so there can be the `ade` group to manage the data and the `ade-trino-access` group for viewing the data.

Signed-off-by: Eric Jones <erjones@redhat.com>