### PR TITLE
Adding access to CCX data to CEE associates

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -154,7 +154,7 @@
         "privileges": ["SELECT"]
     },
     {
-        "group": "ccx-dev|assisted-lakers|ccx-datalake-access|ceeandpe|na-cs-tam-auto|apac-cs-tam-auto|latam-cs-tam-auto|emea-cs-tam-auto|na-ps-cs-tam-auto|emea-cs-csm-auto|emea-cs-cse-auto|emea-cs-managers|apac-cs-csm-auto|apac-cs-cse-auto|na-cs-csm-auto|na-cs-cse-auto|na-ps-cs-cse-auto|latam-cs-csm-auto|cs-csa-auto-ccx|ccx-pm|telemeter-auth|telemeter-auto-approval|telemeter-manual-approval",
+        "group": "ccx-dev|assisted-lakers|ccx-datalake-access|ceeandpe|na-cs-tam-auto|apac-cs-tam-auto|latam-cs-tam-auto|emea-cs-tam-auto|na-ps-cs-tam-auto|emea-cs-csm-auto|emea-cs-cse-auto|emea-cs-managers|apac-cs-csm-auto|apac-cs-cse-auto|na-cs-csm-auto|na-cs-cse-auto|na-ps-cs-cse-auto|latam-cs-csm-auto|cs-csa-auto-ccx|ccx-pm|telemeter-auth|telemeter-auto-approval|telemeter-manual-approval|cee-sbr-shift",
         "schema": "ccx",
         "privileges": ["SELECT"]
     },
@@ -164,7 +164,7 @@
         "privileges": ["SELECT"]
     },
     {
-        "group": "ccx-dev|assisted-lakers|ccx-sensitive-datalake-access|ceeandpe|na-cs-tam-auto|apac-cs-tam-auto|latam-cs-tam-auto|emea-cs-tam-auto|na-ps-cs-tam-auto|emea-cs-csm-auto|emea-cs-cse-auto|emea-cs-managers|apac-cs-csm-auto|apac-cs-cse-auto|na-cs-csm-auto|na-cs-cse-auto|na-ps-cs-cse-auto|latam-cs-csm-auto|cs-csa-auto-ccx|ccx-pm|telemeter-auth|telemeter-auto-approval|telemeter-manual-approval",
+        "group": "ccx-dev|assisted-lakers|ccx-sensitive-datalake-access|ceeandpe|na-cs-tam-auto|apac-cs-tam-auto|latam-cs-tam-auto|emea-cs-tam-auto|na-ps-cs-tam-auto|emea-cs-csm-auto|emea-cs-cse-auto|emea-cs-managers|apac-cs-csm-auto|apac-cs-cse-auto|na-cs-csm-auto|na-cs-cse-auto|na-ps-cs-cse-auto|latam-cs-csm-auto|cs-csa-auto-ccx|ccx-pm|telemeter-auth|telemeter-auto-approval|telemeter-manual-approval|cee-sbr-shift",
         "schema": "ccx_sensitive",
         "privileges": ["SELECT"]
     },


### PR DESCRIPTION
Access includes sensitive data.
CEE folks have access to account data in Hydra and full OCP data in the supportshell. Therefore with this grant we are not exposing any new data.