### PR TITLE
Remove access to telemetry dh curated schema

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -120,18 +120,8 @@
         "privileges": ["SELECT"]
     },
     {
-        "group": "(telemeter-auth|telemeter-auto-approval|telemeter-manual-approval)",
-        "schema": "telemetry_curated",
-        "privileges": ["SELECT"]
-    },
-    {
         "user": "(telemetry-automated|telemetry-edmund-abbot|telemetry-analytics)",
         "schema": "telemetry",
-        "privileges": ["SELECT"]
-    },
-    {
-        "user": "(telemetry-automated|telemetry-edmund-abbot|telemetry-analytics)",
-        "schema": "telemetry_curated",
         "privileges": ["SELECT"]
     },
     {


### PR DESCRIPTION
We want to decommission the process that produces this data. Revoking access to it is a first step towards ensuring nobody is using it.