### PR TITLE
Change how we specify the s3 sync pipeline timeout

### DIFF
--- a/s3-sync-pipelines/base/s3-sync-pipeline.yaml
+++ b/s3-sync-pipelines/base/s3-sync-pipeline.yaml
@@ -11,6 +11,7 @@ spec:
     - name: sync_config_secret_name
   tasks:
     - name: s3-sync
+      timeout: 10h0m0s
       taskRef:
         name: s3-sync
       params:

--- a/s3-sync-pipelines/base/s3-sync-triggertemplate.yaml
+++ b/s3-sync-pipelines/base/s3-sync-triggertemplate.yaml
@@ -15,8 +15,6 @@ spec:
       metadata:
         generateName: "s3-sync-test-sync-"
       spec:
-        timeouts:
-          pipeline: "10h"
         pipelineRef:
           name: s3-sync
         params:


### PR DESCRIPTION
The way we were doing it before isn't supported yet in our versin of openshift pipelines