### PR TITLE
Add new trino SA for IBM research team

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -48,6 +48,11 @@
         "owner": true
     },
     {
+        "user": "ccx-research-pipeline-trino",
+        "schema": "(ccx|ccx_sensitive)",
+        "owner": true
+    },
+    {
         "group": "cost-management-team",
         "schema": "costmgmt",
         "owner": true
@@ -141,6 +146,11 @@
     {
         "user": "ccx-reporting-pipeline-trino-readonly",
         "schema": "(ccx|ccx_sensitive|ccx_srep|ccx_internal)",
+        "privileges": ["SELECT"]
+    },
+    {
+        "user": "ccx-research-pipeline-trino",
+        "schema": "(ccx|ccx_sensitive)",
         "privileges": ["SELECT"]
     },
     {


### PR DESCRIPTION
IBM research team works on an AI project for ccx
where they are processing certain CCX data.
After the auth changes their automation
won't work without proper SA.