### PR TITLE
Cleanup of the rules depending on users

### DIFF
--- a/kfdefs/base/trino/trino-acl-rules.json
+++ b/kfdefs/base/trino/trino-acl-rules.json
@@ -11,7 +11,7 @@
         "allow": "all"
     },
     {
-        "user": "ccx-admin|ccx-reporting-pipeline-trino",
+        "group": "ccx-datalake-owners",
         "allow": "all"
     },
     {
@@ -28,18 +28,8 @@
         "owner": true
     },
     {
-        "user": "ccx-admin|ccx-reporting-pipeline-trino",
+        "group": "ccx-datalake-owners",
         "schema": "(ccx|ccx_sensitive|ccx_srep|ccx_internal|ccx_workloads)",
-        "owner": true
-    },
-    {
-        "group": "ccx-srep-data-access",
-        "schema": "ccx_srep",
-        "owner": true
-    },
-    {
-        "user": "ccx-research-pipeline-trino",
-        "schema": "(ccx|ccx_sensitive)",
         "owner": true
     },
     {
@@ -144,18 +134,13 @@
         "privileges": ["SELECT"]
     },
     {
-        "user": "ccx-admin|ccx-reporting-pipeline-trino",
+        "group": "ccx-datalake-owners",
         "schema": "(ccx|ccx_sensitive|ccx_srep|ccx_internal|ccx_workloads)",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP", "GRANT_SELECT"]
     },
     {
-        "user": "ccx-reporting-pipeline-trino-readonly",
-        "schema": "(ccx|ccx_sensitive|ccx_srep|ccx_internal|ccx_workloads)",
-        "privileges": ["SELECT"]
-    },
-    {
-        "user": "ccx-research-pipeline-trino",
-        "schema": "(ccx|ccx_sensitive)",
+        "group": "ccx-internal-data-access",
+        "schema": "ccx_internal",
         "privileges": ["SELECT"]
     },
     {
@@ -164,23 +149,8 @@
         "privileges": ["SELECT"]
     },
     {
-        "user": "superset-ccx",
-        "schema": "ccx",
-        "privileges": ["SELECT"]
-    },
-    {
         "group": "ccx-dev|assisted-lakers|ccx-sensitive-datalake-access|ceeandpe|na-cs-tam-auto|apac-cs-tam-auto|latam-cs-tam-auto|emea-cs-tam-auto|na-ps-cs-tam-auto|emea-cs-csm-auto|emea-cs-cse-auto|emea-cs-managers|apac-cs-csm-auto|apac-cs-cse-auto|na-cs-csm-auto|na-cs-cse-auto|na-ps-cs-cse-auto|latam-cs-csm-auto|cs-csa-auto-ccx|ccx-pm|telemeter-auth|telemeter-auto-approval|telemeter-manual-approval|cee-sbr-shift|gcs-csm|asr-insights-dashboards",
         "schema": "ccx_sensitive",
-        "privileges": ["SELECT"]
-    },
-    {
-        "user": "superset-ccx-sensitive",
-        "schema": "ccx_sensitive",
-        "privileges": ["SELECT"]
-    },
-    {
-        "user": "(telemetry-automated|telemetry-edmund-abbot|telemetry-analytics)",
-        "schema": "ccx|ccx_sensitive",
         "privileges": ["SELECT"]
     },
     {


### PR DESCRIPTION
- missing groups were created in Rover
- users were added to the respective groups
- accesses for some legacy accounts were removed
