### PR TITLE
Remove unnecessary fields in cvp-ops-admin rolebinding

### DIFF
--- a/s3-webserver/overlays/prod/cvp-ops-admin-rolebinding.yaml
+++ b/s3-webserver/overlays/prod/cvp-ops-admin-rolebinding.yaml
@@ -3,8 +3,6 @@ kind: RoleBinding
 metadata:
   name: cvp-ops-admin
 roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
   name: admin
 subjects:
   - kind: Group


### PR DESCRIPTION
These were throwing off the argocd diff